### PR TITLE
Make boolean argument explicit in `peerInfo.ban(banStatus)` readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ An Array of topics that this Peer is associated with -- `topics` will only be up
 #### `peerInfo.prioritized`
 If true, the swarm will rapidly attempt to reconnect to this peer.
 
-#### `peerInfo.ban()`
-Ban the peer. This will prevent any future reconnection attempts, but it will __not__ close any existing connections.
+#### `peerInfo.ban(banStatus = false)`
+Ban or unban the peer. Banning will prevent any future reconnection attempts, but it will __not__ close any existing connections.
 
 ## License
 MIT

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ module.exports = class Hyperswarm extends EventEmitter {
 
     // TODO: Support async firewalling at some point.
     if (this._handleFirewall(peerInfo.publicKey, null)) {
-      peerInfo.ban()
+      peerInfo.ban(true)
       this._flushMaybe(peerInfo)
       return
     }


### PR DESCRIPTION
The docs seemed to imply that just calling the function would ban the peer but when I looked at the function itself it just sets `this.banned = !!val`. So the function actually requires a boolean to be passed which is the case in tests. Currently the default is actually to unban the peer if no argument is passed. Perhaps it should default to `true`?

Finally I noticed that `peerInfo.ban()` was called after a firewall check but wasn't passed `true`, so I fixed that as well.