### PR TITLE
Add xl backoff to tests

### DIFF
--- a/test/chaos.js
+++ b/test/chaos.js
@@ -9,7 +9,8 @@ const Hyperswarm = require('..')
 const BACKOFFS = [
   100,
   200,
-  300
+  300,
+  400
 ]
 
 test('chaos - recovers after random disconnections (takes ~60s)', async (t) => {

--- a/test/firewall.js
+++ b/test/firewall.js
@@ -8,7 +8,8 @@ const CONNECTION_TIMEOUT = 100
 const BACKOFFS = [
   100,
   200,
-  300
+  300,
+  400
 ]
 
 test('firewalled server - bad client is rejected', async (t) => {

--- a/test/retry-timer.js
+++ b/test/retry-timer.js
@@ -8,7 +8,8 @@ const PeerInfo = require('../lib/peer-info')
 const BACKOFFS = [
   50,
   150,
-  250
+  250,
+  350
 ]
 const MAX_JITTER = 20
 

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -8,7 +8,8 @@ const CONNECTION_TIMEOUT = 100
 const BACKOFFS = [
   100,
   200,
-  300
+  300,
+  400
 ]
 
 test('one server, one client - first connection', async (t) => {


### PR DESCRIPTION
When tests pass a backoffs option, they only defined 3, but RetryTimer expects 4, so it ends up setting the last timer as NaN. This wasn't impacting the tests, but with this PR it's no longer NaN.