### PR TITLE
Force relaying on holepunch aborted

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,9 +74,9 @@ module.exports = class Hyperswarm extends EventEmitter {
     this.dht.on('network-change', this._handleNetworkChange.bind(this))
   }
 
-  _maybeRelayConnection () {
+  _maybeRelayConnection (force) {
     if (!this.relayThrough) return null
-    return this.relayThrough()
+    return this.relayThrough(force)
   }
 
   _enqueue (peerInfo) {
@@ -157,7 +157,7 @@ module.exports = class Hyperswarm extends EventEmitter {
       return
     }
 
-    const relayThrough = this._maybeRelayConnection()
+    const relayThrough = this._maybeRelayConnection(peerInfo.forceRelaying)
     const conn = this.dht.connect(peerInfo.publicKey, {
       relayAddresses: peerInfo.relayAddresses,
       keyPair: this.keyPair,
@@ -185,7 +185,13 @@ module.exports = class Hyperswarm extends EventEmitter {
 
       this.emit('update')
     })
-    conn.on('error', noop)
+    conn.on('error', err => {
+      if (this.relayThrough && (err.code === 'HOLEPUNCH_ABORTED')) {
+        peerInfo.forceRelaying = true
+        // Reset the attempts in order to fast connect to relay
+        peerInfo.attempts = 0
+      }
+    })
     conn.on('open', () => {
       opened = true
       this._connectDone()

--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ module.exports = class Hyperswarm extends EventEmitter {
       this.emit('update')
     })
     conn.on('error', err => {
-      if (this.relayThrough && (err.code === 'HOLEPUNCH_ABORTED')) {
+      if (this.relayThrough && shouldForceRelaying(err.code)) {
         peerInfo.forceRelaying = true
         // Reset the attempts in order to fast connect to relay
         peerInfo.attempts = 0
@@ -504,4 +504,10 @@ function noop () { }
 
 function allowAll () {
   return false
+}
+
+function shouldForceRelaying (code) {
+  return (code === 'HOLEPUNCH_ABORTED') ||
+    (code === 'HOLEPUNCH_DOUBLE_RANDOMIZED_NATS') ||
+    (code === 'REMOTE_NOT_HOLEPUNCHABLE')
 }

--- a/lib/peer-info.js
+++ b/lib/peer-info.js
@@ -20,6 +20,7 @@ module.exports = class PeerInfo extends EventEmitter {
     this.tried = false
     this.explicit = false
     this.waiting = false
+    this.forceRelaying = false
 
     // Set by the Swarm
     this.queued = false


### PR DESCRIPTION
If `dht.connect` fails with a `HOLEPUNCH_ABORTED` error, we should mark that peer as `forceRelaying = true`, which will force all subsequent connection attempts to go through the provided relay (if `relayThrough` is specified).

Also, when `forceRelaying` is set, `attempts` is reset in order to get `VERY_HIGH_PRIORITY` on the subsequent relay connection attempt.