### PR TITLE
Test swarm.flush() behaviour

### DIFF
--- a/test/swarm.js
+++ b/test/swarm.js
@@ -668,7 +668,7 @@ test('joining and awaiting swarm.flush() on both sides => connection made on las
     await Promise.all([swarm1.destroy(), swarm2.destroy()])
   })
 
-  t.is(swarm1.connections.size, 0, 'Sanity check: initial connections.size is 0')
+  t.is(swarm2.connections.size, 0, 'Sanity check: initial connections.size is 0')
 
   swarm1.on('connection', (conn) => {
     conn.on('error', noop)

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -659,7 +659,7 @@ test('peer-discovery object deleted when corresponding connection closes (client
 })
 
 test('joining and awaiting swarm.flush() on both sides => connection made on last flusher', async t => {
-  t.plan(4)
+  t.plan(6)
   const { bootstrap } = await createTestnet(3, t.teardown)
 
   const swarm1 = new Hyperswarm({ bootstrap })
@@ -690,6 +690,8 @@ test('joining and awaiting swarm.flush() on both sides => connection made on las
   const connection = [...swarm2.connections.entries()][0][0]
   connection.on('data', async d => {
     t.is(b4a.toString(d), 'Please echo me', 'connection works correctly')
+    t.is(swarm1.connections.size, 1, 'Swarm1 has 1 connection')
+    t.is(swarm2.connections.size, 1, 'Swarm2 has 1 connection')
   })
   connection.on('error', noop)
   connection.write(b4a.from('Please echo me'))


### PR DESCRIPTION
<strike>
Includes a failing test on swarm.flush() behaviour, and another one on the more low-level .flushed() behaviour on the result of swarm.join()

There's some odd timing thing going on, but it might not be relevant. In the swarm test, awaiting a setImmediate does not fix the failing test, but awaiting a setTimeout(0) does fix it. For the more low-level test, both setImmediate and setTimeout(0) fail (waiting a longer time does make it pass)

This behaviour started between now and 7 days ago, so I think something must have changed in the dependencies (no real changes in hyperswarm since then)
</strike>

The expected behaviour is in fact that the last to flush has a connection (swarm2 in the tests), but there's no guarantee on swarm1 already having the connection.

The test is now updated to test the expected behaviour