### PR TITLE
Fix flaky retry-timer test

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "standard": "^17.0.0"
   },
   "scripts": {
-    "test": "standard && node test/all.js",
+    "test": "standard && node test/retry-timer.js",
     "test:generate": "brittle -r test/all.js test/*.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "standard": "^17.0.0"
   },
   "scripts": {
-    "test": "standard && node test/retry-timer.js",
+    "test": "standard && node test/all.js",
     "test:generate": "brittle -r test/all.js test/*.js"
   },
   "repository": {

--- a/test/retry-timer.js
+++ b/test/retry-timer.js
@@ -16,28 +16,32 @@ const MAX_JITTER = 20
 const isLinux = process.platform === 'linux'
 
 // Windows and Mac CI are slow, running on Linux only is enough
-test('retry timer - proven peer reinsertion', { skip: !isLinux }, async (t) => {
-  let calls = 0
-  const rt = new RetryTimer(() => calls++, {
-    backoffs: BACKOFFS,
-    jitter: MAX_JITTER
+for (let i = 0; i < 200; i++) {
+  test('retry timer - proven peer reinsertion', { skip: !isLinux }, async (t) => {
+    let calls = 0
+    const rt = new RetryTimer(() => calls++, {
+      backoffs: BACKOFFS,
+      jitter: MAX_JITTER
+    })
+
+    const peerInfo = randomPeerInfo()
+
+    rt.add(peerInfo)
+
+    const msMargin = 50
+    await timeout(BACKOFFS[0] + MAX_JITTER + msMargin)
+    t.is(calls, 1)
+
+    setQuickRetry(peerInfo)
+    rt.add(peerInfo)
+
+    await timeout(BACKOFFS[0] + MAX_JITTER + msMargin)
+
+    t.is(calls, 2)
+
+    rt.destroy()
   })
-
-  const peerInfo = randomPeerInfo()
-
-  rt.add(peerInfo)
-
-  await timeout(BACKOFFS[0] + MAX_JITTER)
-
-  setQuickRetry(peerInfo)
-  rt.add(peerInfo)
-
-  await timeout(BACKOFFS[0] + MAX_JITTER)
-
-  t.is(calls, 2)
-
-  rt.destroy()
-})
+}
 
 test('retry timer - forget unresponsive', async (t) => {
   let calls = 0

--- a/test/retry-timer.js
+++ b/test/retry-timer.js
@@ -16,32 +16,30 @@ const MAX_JITTER = 20
 const isLinux = process.platform === 'linux'
 
 // Windows and Mac CI are slow, running on Linux only is enough
-for (let i = 0; i < 200; i++) {
-  test('retry timer - proven peer reinsertion', { skip: !isLinux }, async (t) => {
-    let calls = 0
-    const rt = new RetryTimer(() => calls++, {
-      backoffs: BACKOFFS,
-      jitter: MAX_JITTER
-    })
-
-    const peerInfo = randomPeerInfo()
-
-    rt.add(peerInfo)
-
-    const msMargin = 50
-    await timeout(BACKOFFS[0] + MAX_JITTER + msMargin)
-    t.is(calls, 1)
-
-    setQuickRetry(peerInfo)
-    rt.add(peerInfo)
-
-    await timeout(BACKOFFS[0] + MAX_JITTER + msMargin)
-
-    t.is(calls, 2)
-
-    rt.destroy()
+test('retry timer - proven peer reinsertion', { skip: !isLinux }, async (t) => {
+  let calls = 0
+  const rt = new RetryTimer(() => calls++, {
+    backoffs: BACKOFFS,
+    jitter: MAX_JITTER
   })
-}
+
+  const peerInfo = randomPeerInfo()
+
+  rt.add(peerInfo)
+
+  const msMargin = 50
+  await timeout(BACKOFFS[0] + MAX_JITTER + msMargin)
+  t.is(calls, 1)
+
+  setQuickRetry(peerInfo)
+  rt.add(peerInfo)
+
+  await timeout(BACKOFFS[0] + MAX_JITTER + msMargin)
+
+  t.is(calls, 2)
+
+  rt.destroy()
+})
 
 test('retry timer - forget unresponsive', async (t) => {
   let calls = 0


### PR DESCRIPTION
The 'retry timer - proven peer reinsertion' test is flaky, I think because there's 0 margin built-in. I added an additional check to verify that the retry was triggered once after the first wait, and noticed that it rarely was, so I added some margin.

I'm not 100% sure that the changes I made make sense though, so do review.

This is an example output for a failing run of the old test:

```
# retry timer - proven peer reinsertion
    not ok 1 - should be equal
      ---
      actual: 1
      expected: 2
      operator: is
      source: |
        
          t.is(calls, 2)
        ----^
        
          rt.destroy()
      stack: |
        ./test/retry-timer.js:37:5
        runNextTicks (node:internal/process/task_queues:60:5)
        process.processTimers (node:internal/timers:511:9)
        async Test._run (./node_modules/brittle/index.js:573:7)
` ` 