### PR TITLE
replaced tests timeouts with flush helper

### DIFF
--- a/test/firewall.js
+++ b/test/firewall.js
@@ -31,7 +31,6 @@ test('firewalled server - bad client is rejected', async (t) => {
   await swarm2.join(topic, { client: false, server: true }).flushed()
 
   swarm1.join(topic, { client: true, server: false })
-  await swarm1.flush()
   await flushConnections(swarm1)
 
   t.alike(serverConnections, 0, 'server did not receive an incoming connection')
@@ -60,7 +59,6 @@ test('firewalled client - bad server is rejected', async (t) => {
   await swarm1.join(topic, { client: false, server: true }).flushed()
 
   swarm2.join(topic, { client: true, server: false })
-  await swarm2.flush()
   await flushConnections(swarm2)
 
   t.alike(clientConnections, 0, 'client did not receive an incoming connection')

--- a/test/firewall.js
+++ b/test/firewall.js
@@ -1,6 +1,6 @@
 const test = require('brittle')
 const createTestnet = require('hyperdht/testnet')
-const { timeout } = require('./helpers')
+const { timeout, flushConnections } = require('./helpers')
 
 const Hyperswarm = require('..')
 
@@ -32,6 +32,7 @@ test('firewalled server - bad client is rejected', async (t) => {
 
   swarm1.join(topic, { client: true, server: false })
   await swarm1.flush()
+  await flushConnections(swarm1)
 
   t.alike(serverConnections, 0, 'server did not receive an incoming connection')
 
@@ -60,6 +61,7 @@ test('firewalled client - bad server is rejected', async (t) => {
 
   swarm2.join(topic, { client: true, server: false })
   await swarm2.flush()
+  await flushConnections(swarm2)
 
   t.alike(clientConnections, 0, 'client did not receive an incoming connection')
 

--- a/test/firewall.js
+++ b/test/firewall.js
@@ -4,7 +4,6 @@ const { timeout } = require('./helpers')
 
 const Hyperswarm = require('..')
 
-const CONNECTION_TIMEOUT = 100
 const BACKOFFS = [
   100,
   200,
@@ -32,8 +31,7 @@ test('firewalled server - bad client is rejected', async (t) => {
   await swarm2.join(topic, { client: false, server: true }).flushed()
 
   swarm1.join(topic, { client: true, server: false })
-
-  await timeout(CONNECTION_TIMEOUT)
+  await swarm1.flush()
 
   t.alike(serverConnections, 0, 'server did not receive an incoming connection')
 
@@ -61,8 +59,7 @@ test('firewalled client - bad server is rejected', async (t) => {
   await swarm1.join(topic, { client: false, server: true }).flushed()
 
   swarm2.join(topic, { client: true, server: false })
-
-  await timeout(CONNECTION_TIMEOUT)
+  await swarm2.flush()
 
   t.alike(clientConnections, 0, 'client did not receive an incoming connection')
 

--- a/test/firewall.js
+++ b/test/firewall.js
@@ -41,6 +41,7 @@ test('firewalled server - bad client is rejected', async (t) => {
 
 test('firewalled client - bad server is rejected', async (t) => {
   const { bootstrap } = await createTestnet(3, t.teardown)
+  t.plan(2)
 
   const swarm1 = new Hyperswarm({ bootstrap, backoffs: BACKOFFS, jitter: 0 })
   const swarm2 = new Hyperswarm({
@@ -48,7 +49,9 @@ test('firewalled client - bad server is rejected', async (t) => {
     backoffs: BACKOFFS,
     jitter: 0,
     firewall: remotePublicKey => {
-      return remotePublicKey.equals(swarm1.keyPair.publicKey)
+      const firewalled = remotePublicKey.equals(swarm1.keyPair.publicKey)
+      t.ok(firewalled, 'The peer got firewalled')
+      return firewalled
     }
   })
 

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,3 +1,7 @@
 exports.timeout = function timeout (ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
+
+exports.flushConnections = function (swarm) {
+  return Promise.all(Array.from(swarm.connections).map(e => e.flush()))
+}

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -4,5 +4,6 @@ exports.timeout = function timeout (ms) {
 
 exports.flushConnections = async function (swarm) {
   await swarm.flush()
-  return Promise.all(Array.from(swarm.connections).map(e => e.flush()))
+  await Promise.all(Array.from(swarm.connections).map(e => e.flush()))
+  await new Promise(resolve => setImmediate(resolve))
 }

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -2,6 +2,7 @@ exports.timeout = function timeout (ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-exports.flushConnections = function (swarm) {
+exports.flushConnections = async function (swarm) {
+  await swarm.flush()
   return Promise.all(Array.from(swarm.connections).map(e => e.flush()))
 }

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -37,9 +37,7 @@ test('one server, one client - first connection', async (t) => {
 
   const topic = Buffer.alloc(32).fill('hello world')
   await swarm1.join(topic, { server: true, client: false }).flushed()
-
   swarm2.join(topic, { client: true, server: false })
-  await flushConnections(swarm2)
 })
 
 test('two servers - first connection', async (t) => {
@@ -207,9 +205,6 @@ test('two servers, two clients - simple deduplication', async (t) => {
   const topic = Buffer.alloc(32).fill('hello world')
   await swarm1.join(topic).flushed()
   await swarm2.join(topic).flushed()
-
-  await flushConnections(swarm2)
-  await flushConnections(swarm1)
 })
 
 test('one server, two clients - topic multiplexing', async (t) => {
@@ -567,10 +562,9 @@ test('multiple discovery sessions with different opts', async (t) => {
   await swarm1.flush()
 
   const discovery1 = swarm2.join(topic, { client: true, server: false })
-  const discovery2 = swarm2.join(topic, { client: false, server: true })
+  swarm2.join(topic, { client: false, server: true })
 
   await discovery1.destroy() // should not prevent server connections
-  await discovery2.flushed()
 })
 
 test('closing all discovery sessions clears all peer-discovery objects', async t => {


### PR DESCRIPTION
This PR replaces the timeouts in tests that could be replaced by the flush helper. It does not replace back off timeouts because the logic for does tests do not allow the replacement.