### PR TITLE
Unflake + clean up single-reconnect test

### DIFF
--- a/test/swarm.js
+++ b/test/swarm.js
@@ -79,39 +79,46 @@ test('one server, one client - single reconnect', async (t) => {
   const swarm1 = new Hyperswarm({ bootstrap, backoffs: BACKOFFS, jitter: 0 })
   const swarm2 = new Hyperswarm({ bootstrap, backoffs: BACKOFFS, jitter: 0 })
 
-  const reconnection1Test = t.test('reconnection1')
-  const reconnection2Test = t.test('reconnection2')
+  const serverReconnectsTest = t.test('server reconnects')
+  const clientReconnectsTest = t.test('client reconnects')
 
-  reconnection1Test.plan(1)
-  reconnection2Test.plan(1)
+  serverReconnectsTest.plan(1)
+  clientReconnectsTest.plan(1)
 
   t.teardown(async () => {
     await swarm1.destroy()
     await swarm2.destroy()
   })
 
-  let clientDisconnected = false
+  let hasClientConnected = false
   let serverDisconnected = false
 
   swarm2.on('connection', (conn) => {
     conn.on('error', noop)
-    if (!clientDisconnected) {
-      clientDisconnected = true
-      conn.destroy()
+
+    if (!hasClientConnected) {
+      hasClientConnected = true
       return
     }
-    reconnection2Test.pass('client')
-    conn.end()
+
+    clientReconnectsTest.pass('client reconnected')
   })
-  swarm1.on('connection', (conn) => {
+
+  swarm1.on('connection', async (conn) => {
     conn.on('error', noop)
+
     if (!serverDisconnected) {
       serverDisconnected = true
+
+      // Ensure connection is setup for client too
+      // before we destroy it
+      await flushConnections(swarm2)
+      if (!hasClientConnected) t.fail('Logical error in the test: the client should be connected by now')
+
       conn.destroy()
       return
     }
-    reconnection1Test.pass('client')
-    conn.end()
+    serverReconnectsTest.pass('Server reconnected')
   })
 
   const topic = Buffer.alloc(32).fill('hello world')


### PR DESCRIPTION
Simplifies the test by letting only one side destroy the connection.

In the previous version, both sides of the connection destroyed it, which occasionally resulted in race conditions on the test logic (related to one swarm already re-establishing the connection before the other side had closed it)
