### PR TITLE
unflake one server, two clients test

### DIFF
--- a/test/swarm.js
+++ b/test/swarm.js
@@ -284,19 +284,11 @@ test('one server, two clients - first connection', async (t) => {
     conn.on('error', noop)
   })
   swarm2.on('connection', (conn, info) => {
-    if (b4a.equals(info.publicKey, swarm1.keyPair.publicKey)) {
-      connection2Test.pass('swarm2 connected with swarm1')
-    } else {
-      t.fail('Unexpected connection')
-    }
+    connection2Test.ok(b4a.equals(info.publicKey, swarm1.keyPair.publicKey), 'swarm2 connected with swarm1')
     conn.on('error', noop)
   })
   swarm3.on('connection', (conn, info) => {
-    if (b4a.equals(info.publicKey, swarm1.keyPair.publicKey)) {
-      connection3Test.pass('swarm3 connected with swarm1')
-    } else {
-      t.fail('Unexpected connection')
-    }
+    connection3Test.ok(b4a.equals(info.publicKey, swarm1.keyPair.publicKey), 'swarm3 connected with swarm1')
     conn.on('error', noop)
   })
 

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -256,8 +256,8 @@ test('one server, two clients - first connection', async (t) => {
   const swarm2 = new Hyperswarm({ bootstrap })
   const swarm3 = new Hyperswarm({ bootstrap })
 
-  const connection1To2Test = t.test('connection1')
-  const connection1To3Test = t.test('connection1')
+  const connection1To2Test = t.test('connection 1 to 2')
+  const connection1To3Test = t.test('connection 1 to 3')
 
   const connection2Test = t.test('connection2')
   const connection3Test = t.test('connection3')

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -1,6 +1,7 @@
 const test = require('brittle')
 const createTestnet = require('hyperdht/testnet')
 const { timeout, flushConnections } = require('./helpers')
+const b4a = require('b4a')
 
 const Hyperswarm = require('..')
 
@@ -248,51 +249,61 @@ test('one server, two clients - topic multiplexing', async (t) => {
   await swarm2.destroy()
 })
 
-test('one server, two clients - first connection', async (t) => {
-  const { bootstrap } = await createTestnet(3, t.teardown)
+for (let i = 0; i < 10000; i++) {
+  test('one server, two clients - first connection', async (t) => {
+    const { bootstrap } = await createTestnet(3, t.teardown)
 
-  const swarm1 = new Hyperswarm({ bootstrap })
-  const swarm2 = new Hyperswarm({ bootstrap })
-  const swarm3 = new Hyperswarm({ bootstrap })
+    const swarm1 = new Hyperswarm({ bootstrap })
+    const swarm2 = new Hyperswarm({ bootstrap })
+    const swarm3 = new Hyperswarm({ bootstrap })
 
-  const connection1Test = t.test('connection1')
-  const connection2Test = t.test('connection2')
-  const connection3Test = t.test('connection3')
+    const connection1Test = t.test('connection1')
+    const connection2Test = t.test('connection2')
+    const connection3Test = t.test('connection3')
 
-  connection1Test.plan(1)
-  connection2Test.plan(1)
-  connection3Test.plan(1)
+    connection1Test.plan(2)
+    connection2Test.plan(1)
+    connection3Test.plan(1)
 
-  t.teardown(async () => {
-    await swarm1.destroy()
-    await swarm2.destroy()
-    await swarm3.destroy()
+    t.teardown(async () => {
+      await swarm1.destroy()
+      await swarm2.destroy()
+      await swarm3.destroy()
+    })
+
+    swarm1.on('connection', (conn, info) => {
+      if (b4a.equals(info.publicKey, swarm2.keyPair.publicKey)) {
+        connection1Test.pass('Swarm1 connected with swarm2')
+      } else if (b4a.equals(info.publicKey, swarm3.keyPair.publicKey)) {
+        connection1Test.pass('Swarm1 connected with swarm3')
+      } else {
+        connection1Test.fail('Unexpected connection')
+      }
+      conn.on('error', noop)
+    })
+    swarm2.on('connection', (conn, info) => {
+      if (b4a.equals(info.publicKey, swarm1.keyPair.publicKey)) {
+        connection2Test.pass('swarm2 connected with swarm1')
+      } else {
+        t.fail('Unexpected connection')
+      }
+      conn.on('error', noop)
+    })
+    swarm3.on('connection', (conn, info) => {
+      if (b4a.equals(info.publicKey, swarm1.keyPair.publicKey)) {
+        connection3Test.pass('swarm3 connected with swarm1')
+      } else {
+        t.fail('Unexpected connection')
+      }
+      conn.on('error', noop)
+    })
+
+    const topic = Buffer.alloc(32).fill('hello world')
+    await swarm1.join(topic, { server: true, client: false }).flushed()
+    swarm2.join(topic, { server: false, client: true })
+    swarm3.join(topic, { server: false, client: true })
   })
-
-  swarm1.on('connection', (conn) => {
-    connection1Test.pass('swarm1')
-    conn.on('error', noop)
-    conn.destroy()
-  })
-  swarm2.on('connection', (conn) => {
-    connection2Test.pass('swarm2')
-    conn.on('error', noop)
-    conn.destroy()
-  })
-  swarm3.on('connection', (conn) => {
-    connection3Test.pass('swarm3')
-    conn.on('error', noop)
-    conn.destroy()
-  })
-
-  const topic = Buffer.alloc(32).fill('hello world')
-  await swarm1.join(topic, { server: true, client: false }).flushed()
-  swarm2.join(topic, { server: false, client: true })
-  swarm3.join(topic, { server: false, client: true })
-
-  await swarm2.flush()
-  await swarm3.flush()
-})
+}
 
 test('one server, two clients - if a second client joins after the server leaves, they will not connect', async (t) => {
   t.plan(2)

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -256,11 +256,14 @@ test('one server, two clients - first connection', async (t) => {
   const swarm2 = new Hyperswarm({ bootstrap })
   const swarm3 = new Hyperswarm({ bootstrap })
 
-  const connection1Test = t.test('connection1')
+  const connection1To2Test = t.test('connection1')
+  const connection1To3Test = t.test('connection1')
+
   const connection2Test = t.test('connection2')
   const connection3Test = t.test('connection3')
 
-  connection1Test.plan(2)
+  connection1To2Test.plan(1)
+  connection1To3Test.plan(1)
   connection2Test.plan(1)
   connection3Test.plan(1)
 
@@ -272,11 +275,11 @@ test('one server, two clients - first connection', async (t) => {
 
   swarm1.on('connection', (conn, info) => {
     if (b4a.equals(info.publicKey, swarm2.keyPair.publicKey)) {
-      connection1Test.pass('Swarm1 connected with swarm2')
+      connection1To2Test.pass('Swarm1 connected with swarm2')
     } else if (b4a.equals(info.publicKey, swarm3.keyPair.publicKey)) {
-      connection1Test.pass('Swarm1 connected with swarm3')
+      connection1To3Test.pass('Swarm1 connected with swarm3')
     } else {
-      connection1Test.fail('Unexpected connection')
+      t.fail('Unexpected connection')
     }
     conn.on('error', noop)
   })

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -249,61 +249,59 @@ test('one server, two clients - topic multiplexing', async (t) => {
   await swarm2.destroy()
 })
 
-for (let i = 0; i < 10000; i++) {
-  test('one server, two clients - first connection', async (t) => {
-    const { bootstrap } = await createTestnet(3, t.teardown)
+test('one server, two clients - first connection', async (t) => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
 
-    const swarm1 = new Hyperswarm({ bootstrap })
-    const swarm2 = new Hyperswarm({ bootstrap })
-    const swarm3 = new Hyperswarm({ bootstrap })
+  const swarm1 = new Hyperswarm({ bootstrap })
+  const swarm2 = new Hyperswarm({ bootstrap })
+  const swarm3 = new Hyperswarm({ bootstrap })
 
-    const connection1Test = t.test('connection1')
-    const connection2Test = t.test('connection2')
-    const connection3Test = t.test('connection3')
+  const connection1Test = t.test('connection1')
+  const connection2Test = t.test('connection2')
+  const connection3Test = t.test('connection3')
 
-    connection1Test.plan(2)
-    connection2Test.plan(1)
-    connection3Test.plan(1)
+  connection1Test.plan(2)
+  connection2Test.plan(1)
+  connection3Test.plan(1)
 
-    t.teardown(async () => {
-      await swarm1.destroy()
-      await swarm2.destroy()
-      await swarm3.destroy()
-    })
-
-    swarm1.on('connection', (conn, info) => {
-      if (b4a.equals(info.publicKey, swarm2.keyPair.publicKey)) {
-        connection1Test.pass('Swarm1 connected with swarm2')
-      } else if (b4a.equals(info.publicKey, swarm3.keyPair.publicKey)) {
-        connection1Test.pass('Swarm1 connected with swarm3')
-      } else {
-        connection1Test.fail('Unexpected connection')
-      }
-      conn.on('error', noop)
-    })
-    swarm2.on('connection', (conn, info) => {
-      if (b4a.equals(info.publicKey, swarm1.keyPair.publicKey)) {
-        connection2Test.pass('swarm2 connected with swarm1')
-      } else {
-        t.fail('Unexpected connection')
-      }
-      conn.on('error', noop)
-    })
-    swarm3.on('connection', (conn, info) => {
-      if (b4a.equals(info.publicKey, swarm1.keyPair.publicKey)) {
-        connection3Test.pass('swarm3 connected with swarm1')
-      } else {
-        t.fail('Unexpected connection')
-      }
-      conn.on('error', noop)
-    })
-
-    const topic = Buffer.alloc(32).fill('hello world')
-    await swarm1.join(topic, { server: true, client: false }).flushed()
-    swarm2.join(topic, { server: false, client: true })
-    swarm3.join(topic, { server: false, client: true })
+  t.teardown(async () => {
+    await swarm1.destroy()
+    await swarm2.destroy()
+    await swarm3.destroy()
   })
-}
+
+  swarm1.on('connection', (conn, info) => {
+    if (b4a.equals(info.publicKey, swarm2.keyPair.publicKey)) {
+      connection1Test.pass('Swarm1 connected with swarm2')
+    } else if (b4a.equals(info.publicKey, swarm3.keyPair.publicKey)) {
+      connection1Test.pass('Swarm1 connected with swarm3')
+    } else {
+      connection1Test.fail('Unexpected connection')
+    }
+    conn.on('error', noop)
+  })
+  swarm2.on('connection', (conn, info) => {
+    if (b4a.equals(info.publicKey, swarm1.keyPair.publicKey)) {
+      connection2Test.pass('swarm2 connected with swarm1')
+    } else {
+      t.fail('Unexpected connection')
+    }
+    conn.on('error', noop)
+  })
+  swarm3.on('connection', (conn, info) => {
+    if (b4a.equals(info.publicKey, swarm1.keyPair.publicKey)) {
+      connection3Test.pass('swarm3 connected with swarm1')
+    } else {
+      t.fail('Unexpected connection')
+    }
+    conn.on('error', noop)
+  })
+
+  const topic = Buffer.alloc(32).fill('hello world')
+  await swarm1.join(topic, { server: true, client: false }).flushed()
+  swarm2.join(topic, { server: false, client: true })
+  swarm3.join(topic, { server: false, client: true })
+})
 
 test('one server, two clients - if a second client joins after the server leaves, they will not connect', async (t) => {
   t.plan(2)


### PR DESCRIPTION
The 'one server, two clients - first connection' test was flaky (very rarely though).

The original test had pretty strange behaviour, destroying the connections immediately on opening, and only expecting one connection for swarm1.

I think that the behaviour it was trying to test was that when there is 1 server and 2 clients, the clients connect to the server but not to each other, so I rewrote the test to be much more explicit about that. Good to double check that that is indeed the intention though.

