### PR TITLE
Use safetyCatch err handlers instead of noop

### DIFF
--- a/lib/peer-discovery.js
+++ b/lib/peer-discovery.js
@@ -229,7 +229,7 @@ module.exports = class PeerDiscovery {
   resume () {
     if (!this.suspended) return
     this.suspended = false
-    this.refresh().catch(noop)
+    this.refresh().catch(safetyCatch)
   }
 }
 

--- a/test/chaos.js
+++ b/test/chaos.js
@@ -1,6 +1,7 @@
 const test = require('brittle')
 const crypto = require('hypercore-crypto')
 const createTestnet = require('hyperdht/testnet')
+const safetyCatch = require('safety-catch')
 const { timeout } = require('./helpers')
 
 const Hyperswarm = require('..')
@@ -37,7 +38,7 @@ test('chaos - recovers after random disconnections (takes ~60s)', async (t) => {
     swarm.on('connection', conn => {
       connections.push(conn)
 
-      conn.on('error', noop)
+      conn.on('error', safetyCatch)
       conn.on('close', () => {
         clearInterval(timer)
         const idx = connections.indexOf(conn)
@@ -110,5 +111,3 @@ test('chaos - recovers after random disconnections (takes ~60s)', async (t) => {
 
   for (const swarm of swarms) await swarm.destroy()
 })
-
-function noop () {}

--- a/test/dups.js
+++ b/test/dups.js
@@ -1,5 +1,6 @@
 const test = require('brittle')
 const createTestnet = require('hyperdht/testnet')
+const safetyCatch = require('safety-catch')
 const Hyperswarm = require('../')
 
 test('many servers', async t => {
@@ -23,7 +24,7 @@ test('many servers', async t => {
     swarm.on('connection', conn => {
       missing.add(conn.remotePublicKey.toString('hex'))
 
-      conn.on('error', noop)
+      conn.on('error', safetyCatch)
       conn.on('close', function () {
         missing.delete(conn.remotePublicKey.toString('hex'))
       })
@@ -51,5 +52,3 @@ test('many servers', async t => {
 
   for (const swarm of swarms) await swarm.destroy()
 })
-
-function noop () {}

--- a/test/peer-join.js
+++ b/test/peer-join.js
@@ -1,5 +1,6 @@
 const test = require('brittle')
 const createTestnet = require('hyperdht/testnet')
+const safetyCatch = require('safety-catch')
 
 const Hyperswarm = require('..')
 
@@ -21,7 +22,7 @@ test('join peer - can establish direct connections to public keys', async (t) =>
   let s1Connected = false
 
   swarm2.on('connection', conn => {
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
     if (!s2Connected) {
       firstConnection.pass('swarm2 got its first connection')
       s2Connected = true
@@ -29,7 +30,7 @@ test('join peer - can establish direct connections to public keys', async (t) =>
     connections.pass('swarm2 got a connection')
   })
   swarm1.on('connection', conn => {
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
     if (!s1Connected) {
       firstConnection.pass('swarm1 got its first connection')
       s1Connected = true
@@ -157,12 +158,12 @@ test('leave peer - no memory leak if other side closed connection first', async 
   swarm2.on('connection', conn => {
     conn.once('close', () => close.pass('swarm2 connection closed'))
     open.pass('swarm2 got a connection')
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
   swarm1.on('connection', conn => {
     conn.once('close', () => close.pass('swarm1 connection closed'))
     open.pass('swarm1 got a connection')
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
 
   swarm1.joinPeer(swarm2.keyPair.publicKey)
@@ -183,5 +184,3 @@ test('leave peer - no memory leak if other side closed connection first', async 
 
   swarm1.leavePeer(swarm2.keyPair.publicKey)
 })
-
-function noop () {}

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -1,5 +1,6 @@
 const test = require('brittle')
 const createTestnet = require('hyperdht/testnet')
+const safetyCatch = require('safety-catch')
 const { timeout, flushConnections } = require('./helpers')
 
 const Hyperswarm = require('..')
@@ -26,11 +27,11 @@ test('one server, one client - first connection', async (t) => {
 
   swarm2.on('connection', (conn) => {
     t.pass('swarm2')
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
     conn.end()
   })
   swarm1.on('connection', (conn) => {
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
     conn.end()
   })
 
@@ -57,12 +58,12 @@ test('two servers - first connection', async (t) => {
   })
 
   swarm1.on('connection', (conn) => {
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
     connection1Test.pass('swarm1')
     conn.end()
   })
   swarm2.on('connection', (conn) => {
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
     connection2Test.pass('swarm2')
     conn.end()
   })
@@ -94,7 +95,7 @@ test('one server, one client - single reconnect', async (t) => {
   let serverDisconnected = false
 
   swarm2.on('connection', (conn) => {
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
 
     if (!hasClientConnected) {
       hasClientConnected = true
@@ -105,7 +106,7 @@ test('one server, one client - single reconnect', async (t) => {
   })
 
   swarm1.on('connection', async (conn) => {
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
 
     if (!serverDisconnected) {
       serverDisconnected = true
@@ -135,11 +136,11 @@ test('one server, one client - maximum reconnects', async (t) => {
   let connections = 0
   swarm2.on('connection', (conn, info) => {
     connections++
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
     conn.destroy()
   })
   swarm1.on('connection', (conn) => {
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
 
   const topic = Buffer.alloc(32).fill('hello world')
@@ -164,11 +165,11 @@ test('one server, one client - banned peer does not reconnect', async (t) => {
   swarm2.on('connection', (conn, info) => {
     connections++
     info.ban(true)
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
     conn.destroy()
   })
   swarm1.on('connection', (conn) => {
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
 
   const topic = Buffer.alloc(32).fill('hello world')
@@ -201,11 +202,11 @@ test('two servers, two clients - simple deduplication', async (t) => {
 
   swarm1.on('connection', (conn) => {
     connection1Test.pass('Swarm 1 connection')
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
   swarm2.on('connection', (conn) => {
     connection2Test.pass('Swarm 2 connection')
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
 
   const topic = Buffer.alloc(32).fill('hello world')
@@ -225,10 +226,10 @@ test('one server, two clients - topic multiplexing', async (t) => {
   swarm2.on('connection', (conn, info) => {
     clientConnections++
     peerInfo = info
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
 
-  swarm1.on('connection', (conn) => conn.on('error', noop))
+  swarm1.on('connection', (conn) => conn.on('error', safetyCatch))
 
   const topic1 = Buffer.alloc(32).fill('hello world')
   const topic2 = Buffer.alloc(32).fill('hi world')
@@ -271,17 +272,17 @@ test('one server, two clients - first connection', async (t) => {
 
   swarm1.on('connection', (conn) => {
     connection1Test.pass('swarm1')
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
     conn.destroy()
   })
   swarm2.on('connection', (conn) => {
     connection2Test.pass('swarm2')
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
     conn.destroy()
   })
   swarm3.on('connection', (conn) => {
     connection3Test.pass('swarm3')
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
     conn.destroy()
   })
 
@@ -304,11 +305,11 @@ test('one server, two clients - if a second client joins after the server leaves
   const swarm3 = new Hyperswarm({ bootstrap, backoffs: BACKOFFS, jitter: 0 })
 
   swarm1.on('connection', (conn) => {
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
 
-  swarm2.on('connection', (conn) => conn.on('error', noop))
-  swarm3.on('connection', (conn) => conn.on('error', noop))
+  swarm2.on('connection', (conn) => conn.on('error', safetyCatch))
+  swarm3.on('connection', (conn) => conn.on('error', safetyCatch))
 
   const topic = Buffer.alloc(32).fill('hello world')
   await swarm1.join(topic).flushed()
@@ -341,11 +342,11 @@ test('two servers, one client - refreshing a peer discovery instance discovers n
   let clientConnections = 0
   swarm3.on('connection', (conn) => {
     clientConnections++
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
 
-  swarm1.on('connection', (conn) => conn.on('error', noop))
-  swarm2.on('connection', (conn) => conn.on('error', noop))
+  swarm1.on('connection', (conn) => conn.on('error', safetyCatch))
+  swarm2.on('connection', (conn) => conn.on('error', safetyCatch))
 
   const topic = Buffer.alloc(32).fill('hello world')
   await swarm1.join(topic).flushed()
@@ -385,7 +386,7 @@ test('one server, one client - correct deduplication when a client connection is
 
   swarm1.on('connection', (conn) => {
     serverConnections++
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
     conn.on('data', () => {
       if (++serverData >= 2) {
         t.is(serverConnections, 2, 'Server opened second connection')
@@ -396,7 +397,7 @@ test('one server, one client - correct deduplication when a client connection is
   })
   swarm2.on('connection', (conn) => {
     clientConnections++
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
     conn.on('data', () => {
       if (++clientData >= 2) {
         t.is(clientConnections, 2, 'Client opened second connection')
@@ -443,11 +444,11 @@ test('constructor options - debug options forwarded to DHT constructor', async (
 
   swarm1.once('connection', (conn) => {
     connected.pass('swarm1')
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
   swarm2.once('connection', (conn) => {
     connected.pass('swarm2')
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
 
   const topic = Buffer.alloc(32).fill('hello world')
@@ -477,12 +478,12 @@ test('flush when max connections reached', async (t) => {
   await swarm1.join(topic, { server: true }).flushed()
 
   await swarm2
-    .on('connection', (conn) => conn.on('error', noop))
+    .on('connection', (conn) => conn.on('error', safetyCatch))
     .join(topic, { client: true })
     .flushed()
 
   await swarm3
-    .on('connection', (conn) => conn.on('error', noop))
+    .on('connection', (conn) => conn.on('error', safetyCatch))
     .join(topic, { client: true })
     .flushed()
 
@@ -508,7 +509,7 @@ test('rejoining with different client/server opts refreshes', async (t) => {
   await swarm1.join(topic, { client: true, server: true }).flushed()
 
   await swarm2
-    .on('connection', (conn) => conn.on('error', noop))
+    .on('connection', (conn) => conn.on('error', safetyCatch))
     .join(topic, { client: true })
     .flushed()
 
@@ -559,12 +560,12 @@ test('multiple discovery sessions with different opts', async (t) => {
 
   swarm1.on('connection', (conn) => {
     connection1Test.pass('swarm1')
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
 
   swarm2.on('connection', (conn) => {
     connection2Test.pass('swarm2')
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
 
   await swarm1.join(topic).flushed()
@@ -610,11 +611,11 @@ test('peer-discovery object deleted when corresponding connection closes (server
 
   swarm2.on('connection', (conn) => {
     connected.pass('swarm2')
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
   swarm1.on('connection', (conn) => {
     otherConnected.pass('swarm1')
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
 
   const topic = Buffer.alloc(32).fill('hello world')
@@ -661,10 +662,10 @@ test('peer-discovery object deleted when corresponding connection closes (client
 
   swarm2.on('connection', (conn) => {
     connected.pass('swarm2')
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
   swarm1.on('connection', (conn) => {
-    conn.on('error', noop)
+    conn.on('error', safetyCatch)
   })
 
   const topic = Buffer.alloc(32).fill('hello world')
@@ -676,8 +677,6 @@ test('peer-discovery object deleted when corresponding connection closes (client
   t.is(swarm2.peers.size, 1)
   await swarm1.destroy()
 })
-
-function noop () {}
 
 function eventFlush () {
   return new Promise(resolve => setImmediate(resolve))


### PR DESCRIPTION
Note: I could not figure out why the `noop`-err-listener was removed here: https://github.com/holepunchto/hyperswarm/blob/21390bfcb11f29c963ff98f5158d87e6e4ae47bd/index.js#L178 . No noop-error-handler seems to be set in that method, and in hyperdht's connect method it's only set in only one place which seems irrelevant: https://github.com/holepunchto/hyperdht/blob/4e30215fd7e75370516df35abafe174d43b26ac5/lib/connect.js#L411

If we want to be safe, we could remove both a noop and a safetyCatch handler there, although it seems plausible that neither is needed.

For now it's just removing a safetyCatch listener, which should be compat with hyperdht as it's no longer using noop handlers once https://github.com/holepunchto/hyperdht/pull/154 is in