### PR TITLE
count the number of connection events

### DIFF
--- a/index.js
+++ b/index.js
@@ -333,7 +333,7 @@ module.exports = class Hyperswarm extends EventEmitter {
     return peerInfo
   }
 
-  _handleUpdate = () => {
+  _handleUpdate () {
     this.stats.updates++
   }
 
@@ -480,7 +480,6 @@ module.exports = class Hyperswarm extends EventEmitter {
     }
 
     await this.dht.destroy({ force })
-    this.removeListener('update', this._handleUpdate)
   }
 
   async suspend () {

--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ module.exports = class Hyperswarm extends EventEmitter {
     this.peers = new Map()
     this.explicitPeers = new Set()
     this.listening = null
+    this.stats = { updates: 0 }
 
     this._discovery = new Map()
     this._timer = new RetryTimer(this._requeue.bind(this), {
@@ -74,6 +75,7 @@ module.exports = class Hyperswarm extends EventEmitter {
     this._firewall = firewall
 
     this.dht.on('network-change', this._handleNetworkChange.bind(this))
+    this.on('update', this._handleUpdate)
   }
 
   _maybeRelayConnection (force) {
@@ -331,6 +333,10 @@ module.exports = class Hyperswarm extends EventEmitter {
     return peerInfo
   }
 
+  _handleUpdate = () => {
+    this.stats.updates++
+  }
+
   _maybeDeletePeer (peerInfo) {
     if (!peerInfo.shouldGC()) return
 
@@ -474,6 +480,7 @@ module.exports = class Hyperswarm extends EventEmitter {
     }
 
     await this.dht.destroy({ force })
+    this.removeListener('update', this._handleUpdate)
   }
 
   async suspend () {


### PR DESCRIPTION
following a similar pattern to the [recent hyperdht addition](https://github.com/holepunchto/hyperdht/pull/182), makes the hyperswarm responsible for collecting its own `stats` property.

part of https://github.com/holepunchto/keet-desktop/pull/1665