### PR TITLE
Add connections to stats (opened, closed, attempted)

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,14 @@ module.exports = class Hyperswarm extends EventEmitter {
     this.peers = new Map()
     this.explicitPeers = new Set()
     this.listening = null
-    this.stats = { updates: 0 }
+    this.stats = {
+      updates: 0,
+      connections: {
+        opened: 0,
+        closed: 0,
+        attempted: 0
+      }
+    }
 
     this._discovery = new Map()
     this._timer = new RetryTimer(this._requeue.bind(this), {
@@ -169,12 +176,16 @@ module.exports = class Hyperswarm extends EventEmitter {
     })
     this._allConnections.add(conn)
 
+    this.stats.connections.attempted++
+
     this.connecting++
     this._clientConnections++
     let opened = false
 
     conn.on('open', () => {
       opened = true
+      this.stats.connections.opened++
+
       this._connectDone()
       this.connections.add(conn)
       conn.removeListener('error', noop)
@@ -194,6 +205,8 @@ module.exports = class Hyperswarm extends EventEmitter {
     })
     conn.on('close', () => {
       if (!opened) this._connectDone()
+      this.stats.connections.closed++
+
       this.connections.delete(conn)
       this._allConnections.delete(conn)
       this._clientConnections--

--- a/index.js
+++ b/index.js
@@ -304,6 +304,13 @@ module.exports = class Hyperswarm extends EventEmitter {
       return
     }
 
+    // The _handleServerConnectionSwam path above calls _handleServerConnection
+    // again, so this is the moment where the conn is actually considered 'attempted'
+    this.stats.connects.attempted++
+    conn.on('open', () => {
+      this.stats.connects.opened++
+    })
+
     const peerInfo = this._upsertPeer(conn.remotePublicKey, null)
 
     this.connections.add(conn)
@@ -314,6 +321,7 @@ module.exports = class Hyperswarm extends EventEmitter {
       this.connections.delete(conn)
       this._allConnections.delete(conn)
       this._serverConnections--
+      this.stats.connects.closed++
 
       this._maybeDeletePeer(peerInfo)
 

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = class Hyperswarm extends EventEmitter {
     this.listening = null
     this.stats = {
       updates: 0,
-      connections: {
+      connects: {
         opened: 0,
         closed: 0,
         attempted: 0
@@ -176,7 +176,7 @@ module.exports = class Hyperswarm extends EventEmitter {
     })
     this._allConnections.add(conn)
 
-    this.stats.connections.attempted++
+    this.stats.connects.attempted++
 
     this.connecting++
     this._clientConnections++
@@ -184,7 +184,7 @@ module.exports = class Hyperswarm extends EventEmitter {
 
     conn.on('open', () => {
       opened = true
-      this.stats.connections.opened++
+      this.stats.connects.opened++
 
       this._connectDone()
       this.connections.add(conn)
@@ -205,7 +205,7 @@ module.exports = class Hyperswarm extends EventEmitter {
     })
     conn.on('close', () => {
       if (!opened) this._connectDone()
-      this.stats.connections.closed++
+      this.stats.connects.closed++
 
       this.connections.delete(conn)
       this._allConnections.delete(conn)

--- a/test/all.js
+++ b/test/all.js
@@ -14,6 +14,7 @@ async function runTests () {
   await import('./peer-join.js')
   await import('./retry-timer.js')
   await import('./suspend.js')
+  await import('./stats.js')
   await import('./swarm.js')
   await import('./update.js')
 

--- a/test/stats.js
+++ b/test/stats.js
@@ -21,12 +21,12 @@ test('connectionsOpened and connectionsClosed stats', async (t) => {
 
   swarm2.on('connection', (conn) => {
     conn.on('error', noop)
-    tOpen.is(swarm2.stats.connections.opened, 1, 'opened connection is in stats')
-    tOpen.is(swarm2.stats.connections.attempted, 1, 'attemped connection is in stats')
-    tClose.is(swarm2.stats.connections.closed, 0, 'sanity check')
+    tOpen.is(swarm2.stats.connects.opened, 1, 'opened connection is in stats')
+    tOpen.is(swarm2.stats.connects.attempted, 1, 'attemped connection is in stats')
+    tClose.is(swarm2.stats.connects.closed, 0, 'sanity check')
 
     conn.on('close', () => {
-      tClose.is(swarm2.stats.connections.closed, 1, 'closed connection is in stats')
+      tClose.is(swarm2.stats.connects.closed, 1, 'closed connection is in stats')
     })
 
     conn.destroy()

--- a/test/stats.js
+++ b/test/stats.js
@@ -10,9 +10,9 @@ test('connectionsOpened and connectionsClosed stats', async (t) => {
   const swarm2 = new Hyperswarm({ bootstrap })
 
   const tOpen = t.test('Open connection')
-  tOpen.plan(2)
+  tOpen.plan(4)
   const tClose = t.test('Close connection')
-  tClose.plan(2)
+  tClose.plan(4)
 
   t.teardown(async () => {
     await swarm1.destroy()
@@ -21,6 +21,7 @@ test('connectionsOpened and connectionsClosed stats', async (t) => {
 
   swarm2.on('connection', (conn) => {
     conn.on('error', noop)
+
     tOpen.is(swarm2.stats.connects.opened, 1, 'opened connection is in stats')
     tOpen.is(swarm2.stats.connects.attempted, 1, 'attemped connection is in stats')
     tClose.is(swarm2.stats.connects.closed, 0, 'sanity check')
@@ -29,16 +30,30 @@ test('connectionsOpened and connectionsClosed stats', async (t) => {
       tClose.is(swarm2.stats.connects.closed, 1, 'closed connection is in stats')
     })
 
-    conn.destroy()
+    conn.end()
   })
 
   swarm1.on('connection', (conn) => {
-    conn.on('error', noop)
+    conn.on('error', () => noop)
+
+    conn.on('open', () => {
+      tOpen.is(swarm1.stats.connects.opened, 1, 'opened server connection is in stats')
+      tOpen.is(swarm1.stats.connects.attempted, 1, 'attempted connection is in status')
+      tClose.is(swarm1.stats.connects.closed, 0, 'Sanity checks')
+    })
+
+    conn.on('close', () => {
+      tClose.is(swarm1.stats.connects.closed, 1, 'closed connections is in stats')
+    })
+
+    conn.end()
   })
 
   const topic = Buffer.alloc(32).fill('hello world')
   await swarm1.join(topic, { server: true, client: false }).flushed()
   swarm2.join(topic, { client: true, server: false })
+
+  await tClose
 })
 
 function noop () {}

--- a/test/stats.js
+++ b/test/stats.js
@@ -1,0 +1,44 @@
+const test = require('brittle')
+const createTestnet = require('hyperdht/testnet')
+
+const Hyperswarm = require('..')
+
+test('connectionsOpened and connectionsClosed stats', async (t) => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+
+  const swarm1 = new Hyperswarm({ bootstrap })
+  const swarm2 = new Hyperswarm({ bootstrap })
+
+  const tOpen = t.test('Open connection')
+  tOpen.plan(2)
+  const tClose = t.test('Close connection')
+  tClose.plan(2)
+
+  t.teardown(async () => {
+    await swarm1.destroy()
+    await swarm2.destroy()
+  })
+
+  swarm2.on('connection', (conn) => {
+    conn.on('error', noop)
+    tOpen.is(swarm2.stats.connections.opened, 1, 'opened connection is in stats')
+    tOpen.is(swarm2.stats.connections.attempted, 1, 'attemped connection is in stats')
+    tClose.is(swarm2.stats.connections.closed, 0, 'sanity check')
+
+    conn.on('close', () => {
+      tClose.is(swarm2.stats.connections.closed, 1, 'closed connection is in stats')
+    })
+
+    conn.destroy()
+  })
+
+  swarm1.on('connection', (conn) => {
+    conn.on('error', noop)
+  })
+
+  const topic = Buffer.alloc(32).fill('hello world')
+  await swarm1.join(topic, { server: true, client: false }).flushed()
+  swarm2.join(topic, { client: true, server: false })
+})
+
+function noop () {}

--- a/test/stats.js
+++ b/test/stats.js
@@ -10,7 +10,7 @@ test('connectionsOpened and connectionsClosed stats', async (t) => {
   const swarm2 = new Hyperswarm({ bootstrap })
 
   const tOpen = t.test('Open connection')
-  tOpen.plan(4)
+  tOpen.plan(3)
   const tClose = t.test('Close connection')
   tClose.plan(4)
 
@@ -22,12 +22,12 @@ test('connectionsOpened and connectionsClosed stats', async (t) => {
   swarm2.on('connection', (conn) => {
     conn.on('error', noop)
 
-    tOpen.is(swarm2.stats.connects.opened, 1, 'opened connection is in stats')
-    tOpen.is(swarm2.stats.connects.attempted, 1, 'attemped connection is in stats')
-    tClose.is(swarm2.stats.connects.closed, 0, 'sanity check')
+    tOpen.is(swarm2.stats.connects.client.opened, 1, 'opened connection is in stats')
+    tOpen.is(swarm2.stats.connects.client.attempted, 1, 'attemped connection is in stats')
+    tClose.is(swarm2.stats.connects.client.closed, 0, 'sanity check')
 
     conn.on('close', () => {
-      tClose.is(swarm2.stats.connects.closed, 1, 'closed connection is in stats')
+      tClose.is(swarm2.stats.connects.client.closed, 1, 'closed connection is in stats')
     })
 
     conn.end()
@@ -37,13 +37,12 @@ test('connectionsOpened and connectionsClosed stats', async (t) => {
     conn.on('error', () => noop)
 
     conn.on('open', () => {
-      tOpen.is(swarm1.stats.connects.opened, 1, 'opened server connection is in stats')
-      tOpen.is(swarm1.stats.connects.attempted, 1, 'attempted connection is in status')
-      tClose.is(swarm1.stats.connects.closed, 0, 'Sanity checks')
+      tOpen.is(swarm1.stats.connects.server.opened, 1, 'opened server connection is in stats')
+      tClose.is(swarm1.stats.connects.server.closed, 0, 'Sanity check')
     })
 
     conn.on('close', () => {
-      tClose.is(swarm1.stats.connects.closed, 1, 'closed connections is in stats')
+      tClose.is(swarm1.stats.connects.server.closed, 1, 'closed connections is in stats')
     })
 
     conn.end()


### PR DESCRIPTION
Helps catch cases where connections are continuously closed and re-opened, and connections which never open or get aborted (`connections.attempted - connections.opened`)