### PR TITLE
send keepalives to peers on a network change

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,6 @@ const ERR_MISSING_TOPIC = 'Topic is required and must be a 32-byte buffer'
 const ERR_DESTROYED = 'Swarm has been destroyed'
 const ERR_DUPLICATE = 'Duplicate connection'
 
-const KEEP_ALIVE = b4a.alloc(0)
-
 module.exports = class Hyperswarm extends EventEmitter {
   constructor (opts = {}) {
     super()
@@ -279,7 +277,7 @@ module.exports = class Hyperswarm extends EventEmitter {
       const keepNew = expectedInitiator === conn.isInitiator
 
       if (keepNew === false) {
-        existing.write(KEEP_ALIVE) // check to see if its still alive actually
+        existing.sendKeepAlive()
         conn.on('error', noop)
         conn.destroy(new Error(ERR_DUPLICATE))
         return
@@ -368,7 +366,7 @@ module.exports = class Hyperswarm extends EventEmitter {
   async _handleNetworkChange () {
     // prioritize figuring out if existing connections are dead
     for (const conn of this._allConnections) {
-      conn.sendKeepAlive?.()
+      conn.sendKeepAlive()
     }
 
     const refreshes = []

--- a/index.js
+++ b/index.js
@@ -366,6 +366,11 @@ module.exports = class Hyperswarm extends EventEmitter {
   }
 
   async _handleNetworkChange () {
+    // prioritize figuring out if existing connections are dead
+    for (const conn of this._allConnections) {
+      conn.sendKeepAlive?.()
+    }
+
     const refreshes = []
 
     for (const discovery of this._discovery.values()) {


### PR DESCRIPTION
_I_ can't see any difference with or without this change. Still seems like an ungodly long time (5-8 seconds) between `NETWORK CHANGE` and `...stream-close`.

Can anyone else confirm / deny ?

Testing using my `test/manual/measure-reconnect.js` script and switching networks.
Note: I've even tried commenting out the `conn.setKeepAlive(5000)` line in `test/manual/measure-reconnect.js` to try and give this PR every advantage.
