### PR TITLE
relay first, holepunch later

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ module.exports = class Hyperswarm extends EventEmitter {
       return
     }
 
-    const relayThrough = this._maybeRelayConnection(peerInfo.forceRelaying)
+    const relayThrough = this._maybeRelayConnection(peerInfo.forceRelaying || peerInfo.attempts === 0)
     const conn = this.dht.connect(peerInfo.publicKey, {
       relayAddresses: peerInfo.relayAddresses,
       keyPair: this.keyPair,

--- a/lib/peer-info.js
+++ b/lib/peer-info.js
@@ -66,11 +66,12 @@ module.exports = class PeerInfo extends EventEmitter {
   }
 
   _disconnected () {
-    if (this.connectedTime > -1) {
-      if ((Date.now() - this.connectedTime) >= MIN_CONNECTION_TIME) this.attempts = 0 // fast retry
-      this.connectedTime = -1
+    if (this.connectedTime > -1 && (Date.now() - this.connectedTime) >= MIN_CONNECTION_TIME) {
+      this.attempts = 0 // fast retry
+    } else {
+      this.attempts++
     }
-    this.attempts++
+    this.connectedTime = -1
   }
 
   _deprioritize () {


### PR DESCRIPTION
Currently the swarm _doesn't_ greedily use relays and then switch over to the holepunched connection. I don't know if that's the behavior we _want_ but _if_ it is, then this is my attempt to rectify that.