### PR TITLE
Bugfix: remove initial error handler when a conn opens

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ module.exports = class Hyperswarm extends EventEmitter {
     this._clientConnections++
     let opened = false
 
-    const maybeForceRelayNext = (err) => {
+    const onerror = (err) => {
       if (this.relayThrough && shouldForceRelaying(err.code)) {
         peerInfo.forceRelaying = true
         // Reset the attempts in order to fast connect to relay
@@ -196,7 +196,7 @@ module.exports = class Hyperswarm extends EventEmitter {
     }
 
     // Removed once a connection is opened
-    conn.on('error', maybeForceRelayNext)
+    conn.on('error', onerror)
 
     conn.on('open', () => {
       opened = true
@@ -204,7 +204,7 @@ module.exports = class Hyperswarm extends EventEmitter {
 
       this._connectDone()
       this.connections.add(conn)
-      conn.removeListener('error', maybeForceRelayNext)
+      conn.removeListener('error', onerror)
       peerInfo._connected()
       peerInfo.client = true
       this.emit('connection', conn, peerInfo)


### PR DESCRIPTION
Previous behaviour still left the error handler there, swallowing all errors (due to removing a non-existing noop handler).

Warning: since it swallowed all errors, fixing this might cause upstream to 'break' in the sense that a previously hidden bug suddenly throws (I noticed this when a syntax error in an event handler didn't show up anywhere).