### PR TITLE
Unslab closestNodes in PeerDiscovery

### DIFF
--- a/lib/peer-discovery.js
+++ b/lib/peer-discovery.js
@@ -1,5 +1,6 @@
 const safetyCatch = require('safety-catch')
 const b4a = require('b4a')
+const unslab = require('unslab')
 
 const REFRESH_INTERVAL = 1000 * 60 * 10 // 10 min
 const RANDOM_JITTER = 1000 * 60 * 2 // 2 min
@@ -112,6 +113,7 @@ module.exports = class PeerDiscovery {
     }
 
     // This is set at the very end, when the query completes successfully.
+    query.closestNodes.forEach((n) => { n.id = unslab(n.id) }) // Note: this replaces the query.closestNodes buffers too (which is fine: same bytes but other underlying arrayBuffer)
     this._closestNodes = query.closestNodes
 
     if (clock !== this._refreshes) return

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "bare-events": "^2.2.0",
     "hyperdht": "^6.11.0",
     "safety-catch": "^1.0.2",
-    "shuffled-priority-queue": "^2.1.0"
+    "shuffled-priority-queue": "^2.1.0",
+    "unslab": "^1.2.0"
   },
   "devDependencies": {
     "brittle": "^3.0.2",


### PR DESCRIPTION
Currently they retain the 68kb udx buffers.

Warning: this modifies the Query.closestNodes objects. If this is potentially an issue, I can copy over the entire entry (so including host and port), which isn't much more work.

Alternatively, this could be solved at dht-rpc's Query level, which is a more general solution (but might do more unneeded copying).