### PR TITLE
Unslab publicKey and topic in PeerInfo

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ const { EventEmitter } = require('events')
 const DHT = require('hyperdht')
 const spq = require('shuffled-priority-queue')
 const b4a = require('b4a')
-const unslab = require('unslab')
 
 const PeerInfo = require('./lib/peer-info')
 const RetryTimer = require('./lib/retry-timer')
@@ -424,7 +423,6 @@ module.exports = class Hyperswarm extends EventEmitter {
   // TODO: When you rejoin, it should reannounce + bump lookup priority
   join (topic, opts = {}) {
     if (!topic) throw new Error(ERR_MISSING_TOPIC)
-    topic = unslab(topic)
 
     const topicString = b4a.toString(topic, 'hex')
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const { EventEmitter } = require('events')
 const DHT = require('hyperdht')
 const spq = require('shuffled-priority-queue')
 const b4a = require('b4a')
+const unslab = require('unslab')
 
 const PeerInfo = require('./lib/peer-info')
 const RetryTimer = require('./lib/retry-timer')
@@ -423,6 +424,7 @@ module.exports = class Hyperswarm extends EventEmitter {
   // TODO: When you rejoin, it should reannounce + bump lookup priority
   join (topic, opts = {}) {
     if (!topic) throw new Error(ERR_MISSING_TOPIC)
+    topic = unslab(topic)
 
     const topicString = b4a.toString(topic, 'hex')
 

--- a/index.js
+++ b/index.js
@@ -356,7 +356,7 @@ module.exports = class Hyperswarm extends EventEmitter {
     }
 
     peerInfo = new PeerInfo({
-      publicKey: unslab(publicKey),
+      publicKey,
       relayAddresses
     })
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const { EventEmitter } = require('events')
 const DHT = require('hyperdht')
 const spq = require('shuffled-priority-queue')
 const b4a = require('b4a')
+const unslab = require('unslab')
 
 const PeerInfo = require('./lib/peer-info')
 const RetryTimer = require('./lib/retry-timer')
@@ -355,7 +356,7 @@ module.exports = class Hyperswarm extends EventEmitter {
     }
 
     peerInfo = new PeerInfo({
-      publicKey,
+      publicKey: unslab(publicKey),
       relayAddresses
     })
 
@@ -423,6 +424,8 @@ module.exports = class Hyperswarm extends EventEmitter {
   // TODO: When you rejoin, it should reannounce + bump lookup priority
   join (topic, opts = {}) {
     if (!topic) throw new Error(ERR_MISSING_TOPIC)
+    topic = unslab(topic)
+
     const topicString = b4a.toString(topic, 'hex')
 
     let discovery = this._discovery.get(topicString)

--- a/lib/peer-discovery.js
+++ b/lib/peer-discovery.js
@@ -1,6 +1,5 @@
 const safetyCatch = require('safety-catch')
 const b4a = require('b4a')
-const unslab = require('unslab')
 
 const REFRESH_INTERVAL = 1000 * 60 * 10 // 10 min
 const RANDOM_JITTER = 1000 * 60 * 2 // 2 min
@@ -9,7 +8,7 @@ const DELAY_GRACE_PERIOD = 1000 * 30 // 30s
 module.exports = class PeerDiscovery {
   constructor (swarm, topic, { wait = null, suspended = false, onpeer = noop, onerror = safetyCatch }) {
     this.swarm = swarm
-    this.topic = unslab(topic)
+    this.topic = topic
     this.isClient = false
     this.isServer = false
     this.destroyed = false

--- a/lib/peer-discovery.js
+++ b/lib/peer-discovery.js
@@ -1,5 +1,6 @@
 const safetyCatch = require('safety-catch')
 const b4a = require('b4a')
+const unslab = require('unslab')
 
 const REFRESH_INTERVAL = 1000 * 60 * 10 // 10 min
 const RANDOM_JITTER = 1000 * 60 * 2 // 2 min
@@ -8,7 +9,7 @@ const DELAY_GRACE_PERIOD = 1000 * 30 // 30s
 module.exports = class PeerDiscovery {
   constructor (swarm, topic, { wait = null, suspended = false, onpeer = noop, onerror = safetyCatch }) {
     this.swarm = swarm
-    this.topic = topic
+    this.topic = unslab(topic)
     this.isClient = false
     this.isServer = false
     this.destroyed = false

--- a/lib/peer-info.js
+++ b/lib/peer-info.js
@@ -95,7 +95,10 @@ module.exports = class PeerInfo extends EventEmitter {
   _topic (topic) {
     const topicString = b4a.toString(topic, 'hex')
     if (this._seenTopics.has(topicString)) return
+
     this._seenTopics.add(topicString)
+
+    topic = unslab(topic)
     this.topics.push(topic)
     this.emit('topic', topic)
   }

--- a/lib/peer-info.js
+++ b/lib/peer-info.js
@@ -95,10 +95,7 @@ module.exports = class PeerInfo extends EventEmitter {
   _topic (topic) {
     const topicString = b4a.toString(topic, 'hex')
     if (this._seenTopics.has(topicString)) return
-
     this._seenTopics.add(topicString)
-
-    topic = unslab(topic)
     this.topics.push(topic)
     this.emit('topic', topic)
   }

--- a/lib/peer-info.js
+++ b/lib/peer-info.js
@@ -1,5 +1,6 @@
 const { EventEmitter } = require('events')
 const b4a = require('b4a')
+const unslab = require('unslab')
 
 const MIN_CONNECTION_TIME = 15000
 
@@ -13,7 +14,7 @@ module.exports = class PeerInfo extends EventEmitter {
   constructor ({ publicKey, relayAddresses }) {
     super()
 
-    this.publicKey = publicKey
+    this.publicKey = unslab(publicKey)
     this.relayAddresses = relayAddresses
 
     this.reconnecting = true

--- a/lib/peer-info.js
+++ b/lib/peer-info.js
@@ -29,7 +29,7 @@ module.exports = class PeerInfo extends EventEmitter {
     // Set by the Swarm
     this.queued = false
     this.client = false
-    this.topics = []
+    this.topics = [] // TODO: remove on next major (check with mafintosh for context)
 
     this.attempts = 0
     this.priority = NORMAL_PRIORITY

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "bare-events": "^2.2.0",
     "hyperdht": "^6.11.0",
     "safety-catch": "^1.0.2",
-    "shuffled-priority-queue": "^2.1.0"
+    "shuffled-priority-queue": "^2.1.0",
+    "unslab": "^1.3.0"
   },
   "devDependencies": {
     "brittle": "^3.0.2",


### PR DESCRIPTION
`publicKey` causes a memleak because it retains the udx buffer (68kb).

I don't think the `topic` is currently an issue, and one could argue that it's the user's responsibility to ensure it's unslabbed, but for the sake of being future-proof I also unslabbed it (feel free to remove).