### PR TITLE
Pass port opt on to hyperdht

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,8 @@ module.exports = class Hyperswarm extends EventEmitter {
 
     this.dht = opts.dht || new DHT({
       bootstrap: opts.bootstrap,
-      nodes: opts.nodes
+      nodes: opts.nodes,
+      port: opts.port
     })
     this.server = this.dht.createServer({
       firewall: this._handleFirewall.bind(this),

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -745,4 +745,12 @@ test('topic and peer get unslabbed in PeerInfo', async (t) => {
   swarm2.join(topic, { client: true, server: false })
 })
 
+test('port opt gets passed on to hyperdht', async (t) => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+
+  const swarm1 = new Hyperswarm({ bootstrap, port: [10000, 10100] })
+  t.alike(swarm1.dht.io.portRange, [10000, 10100])
+  await swarm1.destroy()
+})
+
 function noop () {}


### PR DESCRIPTION
I haven't included it in the README for now, because the similar `nodes` and `bootstrap` opts aren't documented either