### PR TITLE
Destroy swarm on exit to ensure swarm is gc'ed

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const DHT = require('hyperdht')
 const spq = require('shuffled-priority-queue')
 const b4a = require('b4a')
 const unslab = require('unslab')
+const goodbye = require('graceful-goodbye')
 
 const PeerInfo = require('./lib/peer-info')
 const RetryTimer = require('./lib/retry-timer')
@@ -90,6 +91,8 @@ module.exports = class Hyperswarm extends EventEmitter {
 
     this.dht.on('network-change', this._handleNetworkChange.bind(this))
     this.on('update', this._handleUpdate)
+    // Ensure GC'ed on exit
+    this._ungoodbye = goodbye(() => this.destroy())
   }
 
   _maybeRelayConnection (force) {
@@ -537,6 +540,7 @@ module.exports = class Hyperswarm extends EventEmitter {
     }
 
     await this.dht.destroy({ force })
+    this._ungoodbye()
   }
 
   async suspend () {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "b4a": "^1.3.1",
     "bare-events": "^2.2.0",
+    "graceful-goodbye": "^1.3.3",
     "hyperdht": "^6.11.0",
     "safety-catch": "^1.0.2",
     "shuffled-priority-queue": "^2.1.0",


### PR DESCRIPTION
Goodbye callback is unregistered when swarm is manually destroyed.