### PR TITLE
Ban peers who are firewalled during server connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Resume a suspended swarm refreshing discovery of new peers and servers. Useful f
 
 `log` is a logging function, which defaults to a noop function.
 
+#### `swarm.on('ban', peerInfo, reason)`
+
+Emitted when a peer gets banned. `reason` is a string describing the reason for the ban.
+
 ## PeerDiscovery API
 
 `swarm.join` returns a `PeerDiscovery` instance which allows you to both control discovery behavior, and respond to lifecycle changes during discovery.

--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ Resume a suspended swarm refreshing discovery of new peers and servers. Useful f
 
 `log` is a logging function, which defaults to a noop function.
 
-#### `swarm.on('ban', peerInfo, reason)`
+#### `swarm.on('ban', peerInfo, err)`
 
-Emitted when a peer gets banned. `reason` is a string describing the reason for the ban.
+Emitted when a peer gets banned. `err` is an error object describing the reason for the ban (e.g. firewalled).
 
 ## PeerDiscovery API
 

--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ module.exports = class Hyperswarm extends EventEmitter {
 
     // TODO: Support async firewalling at some point.
     if (this._handleFirewall(peerInfo.publicKey, null)) {
-      this._banPeer(peerInfo, true, 'firewall')
+      this._banPeer(peerInfo, true, 'client firewall')
       if (queued) this._flushMaybe(peerInfo)
       return
     }

--- a/index.js
+++ b/index.js
@@ -445,8 +445,8 @@ module.exports = class Hyperswarm extends EventEmitter {
 
   _banPeer (peerInfo, banned, reason) {
     peerInfo.ban(banned)
-    this.emit('ban', peerInfo, reason)
     this.stats.bannedPeers++
+    this.emit('ban', peerInfo, reason)
   }
 
   status (key) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "b4a": "^1.3.1",
     "bare-events": "^2.2.0",
-    "hyperdht": "holepunchto/hyperdht#support-firewall-callback",
+    "hyperdht": "^6.21.0",
     "safety-catch": "^1.0.2",
     "shuffled-priority-queue": "^2.1.0",
     "streamx": "^2.22.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "b4a": "^1.3.1",
     "bare-events": "^2.2.0",
-    "hyperdht": "^6.11.0",
+    "hyperdht": "holepunchto/hyperdht#support-firewall-callback",
     "safety-catch": "^1.0.2",
     "shuffled-priority-queue": "^2.1.0",
     "streamx": "^2.22.1",

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -816,9 +816,9 @@ test('ban stat and event', async (t) => {
 
   const swarm1 = new Hyperswarm({ bootstrap, backoffs: BACKOFFS, jitter: 0 })
   const swarm2 = new Hyperswarm({ firewall, bootstrap, backoffs: BACKOFFS, jitter: 0 })
-  swarm2.on('ban', (peerInfo, reason) => {
+  swarm2.on('ban', (peerInfo, err) => {
     t.alike(peerInfo.publicKey, swarm1.keyPair.publicKey)
-    t.alike(reason, 'firewall')
+    t.alike(err.message, 'Peer is firewalled')
   })
 
   swarm2.on('connection', (conn) => {

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -789,19 +789,22 @@ test('firewall for server connections results in peer ban', async (t) => {
   t.is(swarm1.stats.bannedPeers, 1)
 
   // Firewall ran at server side, so we should have banned the peer
-  // To verify, let's disable the firewall
+  // To verify, let's disable the firewall and see if a connection event triggers
   disableFirewall = true
+
+  // We need to wait a while because both sides need to detect the connection closed
+  await timeout(2000)
 
   // Try joining as client
   const topic2 = Buffer.alloc(32).fill('topic2')
   await swarm2.join(topic2, { client: false, server: true }).flushed()
   swarm1.join(topic2, { client: true, server: false })
-  await timeout(500)
 
   // Try joining as server
   const topic3 = Buffer.alloc(32).fill('topic3')
   await swarm1.join(topic3, { client: false, server: true }).flushed()
   swarm2.join(topic3, { client: true, server: false })
+
   await timeout(500)
 
   await swarm1.destroy()

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -753,4 +753,92 @@ test('port opt gets passed on to hyperdht', async (t) => {
   await swarm1.destroy()
 })
 
+test('firewall for server connections results in peer ban', async (t) => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+
+  let firewallRan = true
+  let disableFirewall = false
+  function myFirewall (...args) { // allow none
+    console.log('running firewall', args)
+    firewallRan = true
+    return !disableFirewall
+  }
+
+  // We pass handshakeClearWait to test that a peer is banned
+  // (the default of 10s means we early-return for all new connection
+  // attempts for 10s because of the initial attempt, so we're not testing the ban logic)
+  const swarm1 = new Hyperswarm({ firewall: myFirewall, handshakeClearWait: 100, bootstrap, backoffs: BACKOFFS, jitter: 0 })
+  const swarm2 = new Hyperswarm({ bootstrap, handshakeClearWait: 100, backoffs: BACKOFFS, jitter: 0 })
+  t.is(swarm1.server.handshakeClearWait < 500, true, 'sanity check')
+
+  swarm2.on('connection', (conn) => {
+    t.fail('should not connect due to firewall')
+    conn.on('error', noop)
+  })
+  swarm1.on('connection', (conn) => {
+    t.fail('should not connect due to firewall')
+    conn.on('error', noop)
+  })
+
+  const topic = Buffer.alloc(32).fill('hello world')
+  await swarm1.join(topic, { client: false, server: true }).flushed()
+  swarm2.join(topic, { client: true, server: false })
+  await timeout(500)
+
+  t.is(firewallRan, true, 'sanity check')
+  t.is(swarm1.stats.bannedPeers, 1)
+
+  // Firewall ran at server side, so we should have banned the peer
+  // To verify, let's disable the firewall
+  disableFirewall = true
+
+  // Try joining as client
+  const topic2 = Buffer.alloc(32).fill('topic2')
+  await swarm2.join(topic2, { client: false, server: true }).flushed()
+  swarm1.join(topic2, { client: true, server: false })
+  await timeout(500)
+
+  // Try joining as server
+  const topic3 = Buffer.alloc(32).fill('topic3')
+  await swarm1.join(topic3, { client: false, server: true }).flushed()
+  swarm2.join(topic3, { client: true, server: false })
+  await timeout(500)
+
+  await swarm1.destroy()
+  await swarm2.destroy()
+})
+
+test('ban stat and event', async (t) => {
+  t.plan(3)
+  const { bootstrap } = await createTestnet(3, t.teardown)
+
+  const firewall = () => true // allow none
+
+  const swarm1 = new Hyperswarm({ bootstrap, backoffs: BACKOFFS, jitter: 0 })
+  const swarm2 = new Hyperswarm({ firewall, bootstrap, backoffs: BACKOFFS, jitter: 0 })
+  swarm2.on('ban', (peerInfo, reason) => {
+    console.log(peerInfo)
+    t.alike(peerInfo.publicKey, swarm1.keyPair.publicKey)
+    t.alike(reason, 'firewall')
+  })
+
+  swarm2.on('connection', (conn) => {
+    conn.on('error', noop)
+  })
+  swarm1.on('connection', (conn) => {
+    conn.on('error', noop)
+  })
+
+  const topic = Buffer.alloc(32).fill('hello world')
+  await swarm1.join(topic, { client: false, server: true }).flushed()
+  swarm2.join(topic, { client: true, server: false })
+
+  await timeout(500)
+
+  t.is(swarm2.stats.bannedPeers, 1)
+
+  await swarm1.destroy()
+  await swarm2.destroy()
+})
+
 function noop () {}

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -759,25 +759,22 @@ test('firewall for server connections results in peer ban', async (t) => {
   let firewallRan = true
   let disableFirewall = false
   function myFirewall (...args) { // allow none
-    console.log('running firewall', args)
     firewallRan = true
     return !disableFirewall
   }
 
   // We pass handshakeClearWait to test that a peer is banned
   // (the default of 10s means we early-return for all new connection
-  // attempts for 10s because of the initial attempt, so we're not testing the ban logic)
+  // attempts during 10s because of the initial attempt, so we're not testing the ban logic)
   const swarm1 = new Hyperswarm({ firewall: myFirewall, handshakeClearWait: 100, bootstrap, backoffs: BACKOFFS, jitter: 0 })
   const swarm2 = new Hyperswarm({ bootstrap, handshakeClearWait: 100, backoffs: BACKOFFS, jitter: 0 })
   t.is(swarm1.server.handshakeClearWait < 500, true, 'sanity check')
 
   swarm2.on('connection', (conn) => {
     t.fail('should not connect due to firewall')
-    conn.on('error', noop)
   })
   swarm1.on('connection', (conn) => {
     t.fail('should not connect due to firewall')
-    conn.on('error', noop)
   })
 
   const topic = Buffer.alloc(32).fill('hello world')

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -771,10 +771,10 @@ test('firewall for server connections results in peer ban', async (t) => {
   t.is(swarm1.server.handshakeClearWait < 500, true, 'sanity check')
 
   swarm2.on('connection', (conn) => {
-    t.fail('should not connect due to firewall')
+    t.fail('should not connect due to firewall and ban')
   })
   swarm1.on('connection', (conn) => {
-    t.fail('should not connect due to firewall')
+    t.fail('should not connect due to firewall and ban')
   })
 
   const topic = Buffer.alloc(32).fill('hello world')

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -817,7 +817,6 @@ test('ban stat and event', async (t) => {
   const swarm1 = new Hyperswarm({ bootstrap, backoffs: BACKOFFS, jitter: 0 })
   const swarm2 = new Hyperswarm({ firewall, bootstrap, backoffs: BACKOFFS, jitter: 0 })
   swarm2.on('ban', (peerInfo, reason) => {
-    console.log(peerInfo)
     t.alike(peerInfo.publicKey, swarm1.keyPair.publicKey)
     t.alike(reason, 'firewall')
   })


### PR DESCRIPTION
Current behaviour is that peers who connect to us over our server and who get rejected by the firewall are not banned. This PR ensures they get banned too.