### PR TITLE
Do not firewall when suspended

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,7 +271,6 @@ module.exports = class Hyperswarm extends EventEmitter {
   }
 
   _handleFirewall (remotePublicKey, payload) {
-    if (this.suspended) return true
     if (b4a.equals(remotePublicKey, this.keyPair.publicKey)) return true
 
     const peerInfo = this.peers.get(b4a.toString(remotePublicKey, 'hex'))


### PR DESCRIPTION
This causes no issues in practice with the current code, since we cannot be `suspended` when `_handleFirewall` triggers, but it's still wrong because we ban peers when our firewall denies them entrance, so better to remove the line completely