### PR TITLE
Preserve discovered relay addresses

### DIFF
--- a/index.js
+++ b/index.js
@@ -411,7 +411,11 @@ module.exports = class Hyperswarm extends EventEmitter {
     let peerInfo = this.peers.get(keyString)
 
     if (peerInfo) {
-      peerInfo.relayAddresses = relayAddresses // new is always better
+      // Some public paths update the peer without any new relay data. Preserve the
+      // previously discovered relay addresses unless a caller provides a real update.
+      if (relayAddresses !== null && relayAddresses !== undefined) {
+        peerInfo.relayAddresses = relayAddresses
+      }
       return peerInfo
     }
 

--- a/index.js
+++ b/index.js
@@ -376,7 +376,7 @@ module.exports = class Hyperswarm extends EventEmitter {
     // When reaching here, the connection will always be 'opened' next tick
     this.stats.connects.server.opened++
 
-    const peerInfo = this._upsertPeer(conn.remotePublicKey, null)
+    const peerInfo = this._upsertPeer(conn.remotePublicKey)
 
     this.connections.add(conn)
     this._allConnections.add(conn)
@@ -411,9 +411,9 @@ module.exports = class Hyperswarm extends EventEmitter {
     let peerInfo = this.peers.get(keyString)
 
     if (peerInfo) {
-      // Some public paths update the peer without any new relay data. Preserve the
-      // previously discovered relay addresses unless a caller provides a real update.
-      if (relayAddresses !== null && relayAddresses !== undefined) {
+      // One-arg calls only touch the peer. A provided second arg is authoritative:
+      // arrays update, [] clears to known-empty, and null can explicitly clear hints.
+      if (arguments.length >= 2) {
         peerInfo.relayAddresses = relayAddresses
       }
       return peerInfo
@@ -545,7 +545,7 @@ module.exports = class Hyperswarm extends EventEmitter {
   }
 
   joinPeer(publicKey) {
-    const peerInfo = this._upsertPeer(publicKey, null)
+    const peerInfo = this._upsertPeer(publicKey)
     if (!peerInfo) return
     if (!this.explicitPeers.has(peerInfo)) {
       peerInfo.explicit = true

--- a/index.js
+++ b/index.js
@@ -411,9 +411,9 @@ module.exports = class Hyperswarm extends EventEmitter {
     let peerInfo = this.peers.get(keyString)
 
     if (peerInfo) {
-      // One-arg calls only touch the peer. A provided second arg is authoritative:
-      // arrays update, [] clears to known-empty, and null can explicitly clear hints.
-      if (arguments.length >= 2) {
+      // Unknown relay addresses preserve existing hints. Arrays update, [] records
+      // known-empty, and null explicitly clears.
+      if (relayAddresses !== undefined) {
         peerInfo.relayAddresses = relayAddresses
       }
       return peerInfo

--- a/index.js
+++ b/index.js
@@ -314,7 +314,7 @@ module.exports = class Hyperswarm extends EventEmitter {
 
     const firewalled = this._firewall(remotePublicKey, payload)
     if (firewalled) {
-      if (!peerInfo) peerInfo = this._upsertPeer(remotePublicKey)
+      if (!peerInfo) peerInfo = this._upsertPeer(remotePublicKey, null)
       this._banPeer(peerInfo, true, new Error(ERR_FIREWALL))
     }
 
@@ -376,7 +376,7 @@ module.exports = class Hyperswarm extends EventEmitter {
     // When reaching here, the connection will always be 'opened' next tick
     this.stats.connects.server.opened++
 
-    const peerInfo = this._upsertPeer(conn.remotePublicKey)
+    const peerInfo = this._upsertPeer(conn.remotePublicKey, null)
 
     this.connections.add(conn)
     this._allConnections.add(conn)
@@ -411,9 +411,7 @@ module.exports = class Hyperswarm extends EventEmitter {
     let peerInfo = this.peers.get(keyString)
 
     if (peerInfo) {
-      // Unknown relay addresses preserve existing hints. Arrays update, [] records
-      // known-empty, and null explicitly clears.
-      if (relayAddresses !== undefined) {
+      if (relayAddresses !== null) {
         peerInfo.relayAddresses = relayAddresses
       }
       return peerInfo
@@ -545,7 +543,7 @@ module.exports = class Hyperswarm extends EventEmitter {
   }
 
   joinPeer(publicKey) {
-    const peerInfo = this._upsertPeer(publicKey)
+    const peerInfo = this._upsertPeer(publicKey, null)
     if (!peerInfo) return
     if (!this.explicitPeers.has(peerInfo)) {
       peerInfo.explicit = true

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -476,66 +476,62 @@ test('rejoining with different client/server opts refreshes', async (t) => {
   await swarm2.destroy()
 })
 
-test(
-  'peer keeps discovered relay addresses after a later inbound connection',
-  { timeout: 30000 },
-  async (t) => {
-    const { bootstrap } = await createTestnet(3, t.teardown)
+test('peer keeps discovered relay addresses after a later inbound connection', async (t) => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
 
-    const swarm1 = new Hyperswarm({ bootstrap })
-    // Prevent swarm2 from immediately consuming the discovered peer as an outbound client
-    // connection. That lets us observe the discovered relayAddresses before the later inbound
-    // server-connection path for the same peer runs.
-    const swarm2 = new Hyperswarm({ bootstrap, maxClientConnections: 0 })
+  const swarm1 = new Hyperswarm({ bootstrap })
+  // Prevent swarm2 from immediately consuming the discovered peer as an outbound client
+  // connection. That lets us observe the discovered relayAddresses before the later inbound
+  // server-connection path for the same peer runs.
+  const swarm2 = new Hyperswarm({ bootstrap, maxClientConnections: 0 })
 
-    t.teardown(async () => {
-      await swarm1.destroy()
-      await swarm2.destroy()
-    })
+  t.teardown(async () => {
+    await swarm1.destroy()
+    await swarm2.destroy()
+  })
 
-    const discoveryTopic = Buffer.alloc(32).fill('relay addresses discovery')
-    const inboundTopic = Buffer.alloc(32).fill('relay addresses inbound')
+  const discoveryTopic = Buffer.alloc(32).fill('relay addresses discovery')
+  const inboundTopic = Buffer.alloc(32).fill('relay addresses inbound')
 
-    await swarm1.join(discoveryTopic, { client: false, server: true }).flushed()
-    swarm2.join(discoveryTopic, { client: true, server: false })
+  await swarm1.join(discoveryTopic, { client: false, server: true }).flushed()
+  swarm2.join(discoveryTopic, { client: true, server: false })
 
-    // First hit the normal public discovery path and wait until swarm2 has cached the relay
-    // addresses announced for swarm1.
-    const discoveredPeer = await waitForPeerWithRelayAddresses(swarm2, swarm1.keyPair.publicKey)
-    const relayAddresses = discoveredPeer.relayAddresses.map(({ host, port }) => ({ host, port }))
+  // First hit the normal public discovery path and wait until swarm2 has cached the relay
+  // addresses announced for swarm1.
+  const discoveredPeer = await waitForPeerWithRelayAddresses(swarm2, swarm1.keyPair.publicKey)
+  const relayAddresses = discoveredPeer.relayAddresses.map(({ host, port }) => ({ host, port }))
 
-    t.ok(relayAddresses.length > 0, 'discovery stored relay addresses through the public path')
+  t.ok(relayAddresses.length > 0, 'discovery stored relay addresses through the public path')
 
-    const inboundOnSwarm2 = nextConnectionFromPeer(swarm2, swarm1.keyPair.publicKey)
-    const inboundOnSwarm1 = nextConnectionFromPeer(swarm1, swarm2.keyPair.publicKey)
+  const inboundOnSwarm2 = nextConnectionFromPeer(swarm2, swarm1.keyPair.publicKey)
+  const inboundOnSwarm1 = nextConnectionFromPeer(swarm1, swarm2.keyPair.publicKey)
 
-    // Then use a second topic to make swarm1 dial swarm2, so swarm2 reaches the real
-    // _handleServerConnection(...) path that touches an existing peer without new relay data.
-    await swarm2.join(inboundTopic, { client: false, server: true }).flushed()
-    swarm1.join(inboundTopic, { client: true, server: false })
+  // Then use a second topic to make swarm1 dial swarm2, so swarm2 reaches the real
+  // _handleServerConnection(...) path that touches an existing peer without new relay data.
+  await swarm2.join(inboundTopic, { client: false, server: true }).flushed()
+  swarm1.join(inboundTopic, { client: true, server: false })
 
-    const [serverConn] = await inboundOnSwarm2
-    const [clientConn] = await inboundOnSwarm1
+  const [serverConn] = await inboundOnSwarm2
+  const [clientConn] = await inboundOnSwarm1
 
-    await flushConnections(swarm1)
-    await flushConnections(swarm2)
+  await flushConnections(swarm1)
+  await flushConnections(swarm2)
 
-    const updatedPeer = swarm2.peers.get(b4a.toString(swarm1.keyPair.publicKey, 'hex'))
+  const updatedPeer = swarm2.peers.get(b4a.toString(swarm1.keyPair.publicKey, 'hex'))
 
-    t.alike(
-      updatedPeer.relayAddresses,
-      relayAddresses,
-      'the later inbound server connection should not erase discovered relay addresses'
-    )
+  t.alike(
+    updatedPeer.relayAddresses,
+    relayAddresses,
+    'the later inbound server connection should not erase discovered relay addresses'
+  )
 
-    serverConn.on('error', noop)
-    clientConn.on('error', noop)
-    serverConn.destroy()
-    clientConn.destroy()
-  }
-)
+  serverConn.on('error', noop)
+  clientConn.on('error', noop)
+  serverConn.destroy()
+  clientConn.destroy()
+})
 
-test('_upsertPeer preserves relay addresses on undefined and clears on null', async (t) => {
+test('_upsertPeer preserves relay addresses on null and updates on arrays', async (t) => {
   const swarm = new Hyperswarm({ bootstrap: false })
 
   t.teardown(async () => {
@@ -547,11 +543,15 @@ test('_upsertPeer preserves relay addresses on undefined and clears on null', as
 
   const peerInfo = swarm._upsertPeer(publicKey, relayAddresses)
 
-  swarm._upsertPeer(publicKey, undefined)
-  t.alike(peerInfo.relayAddresses, relayAddresses, 'explicit undefined preserves known hints')
-
   swarm._upsertPeer(publicKey, null)
-  t.is(peerInfo.relayAddresses, null, 'null explicitly clears known hints')
+  t.alike(peerInfo.relayAddresses, relayAddresses, 'null preserves known relay hints')
+
+  swarm._upsertPeer(publicKey, [])
+  t.alike(peerInfo.relayAddresses, [], 'empty array records known-empty relay hints')
+
+  const updatedRelayAddresses = [{ host: '127.0.0.1', port: 4243 }]
+  swarm._upsertPeer(publicKey, updatedRelayAddresses)
+  t.alike(peerInfo.relayAddresses, updatedRelayAddresses, 'array updates known relay hints')
 })
 
 test('joinPeer preserves existing relay addresses', async (t) => {
@@ -569,6 +569,24 @@ test('joinPeer preserves existing relay addresses', async (t) => {
   swarm.joinPeer(publicKey)
 
   t.alike(peerInfo.relayAddresses, relayAddresses, 'joinPeer preserves known relay hints')
+})
+
+test('_handleFirewall creates peers with null relay addresses', async (t) => {
+  const swarm = new Hyperswarm({
+    bootstrap: false,
+    firewall: () => true
+  })
+
+  t.teardown(async () => {
+    await swarm.destroy()
+  })
+
+  const publicKey = Buffer.alloc(32).fill(9)
+
+  t.is(swarm._handleFirewall(publicKey, null), true)
+
+  const peerInfo = swarm.peers.get(b4a.toString(publicKey, 'hex'))
+  t.is(peerInfo.relayAddresses, null)
 })
 
 test('topics returns peer-discovery objects', async (t) => {

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -536,8 +536,7 @@ test(
 )
 
 test('_upsertPeer preserves relay addresses on undefined and clears on null', async (t) => {
-  const { bootstrap } = await createTestnet(3, t.teardown)
-  const swarm = new Hyperswarm({ bootstrap })
+  const swarm = new Hyperswarm({ bootstrap: false })
 
   t.teardown(async () => {
     await swarm.destroy()
@@ -553,6 +552,23 @@ test('_upsertPeer preserves relay addresses on undefined and clears on null', as
 
   swarm._upsertPeer(publicKey, null)
   t.is(peerInfo.relayAddresses, null, 'null explicitly clears known hints')
+})
+
+test('joinPeer preserves existing relay addresses', async (t) => {
+  const swarm = new Hyperswarm({ bootstrap: false, maxParallel: 0 })
+
+  t.teardown(async () => {
+    await swarm.destroy()
+  })
+
+  const publicKey = Buffer.alloc(32).fill(8)
+  const relayAddresses = [{ host: '127.0.0.1', port: 4242 }]
+
+  const peerInfo = swarm._upsertPeer(publicKey, relayAddresses)
+
+  swarm.joinPeer(publicKey)
+
+  t.alike(peerInfo.relayAddresses, relayAddresses, 'joinPeer preserves known relay hints')
 })
 
 test('topics returns peer-discovery objects', async (t) => {

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -535,28 +535,6 @@ test(
   }
 )
 
-test('_upsertPeer preserves relay addresses on touch and clears on explicit null', async (t) => {
-  const { bootstrap } = await createTestnet(3, t.teardown)
-  const swarm = new Hyperswarm({ bootstrap })
-
-  t.teardown(async () => {
-    await swarm.destroy()
-  })
-
-  const publicKey = Buffer.alloc(32).fill('relay address contract')
-  const relayAddresses = [{ host: '1.2.3.4', port: 1234 }]
-
-  const peerInfo = swarm._upsertPeer(publicKey, relayAddresses)
-
-  t.alike(peerInfo.relayAddresses, relayAddresses, 'explicit relay addresses are stored')
-
-  swarm._upsertPeer(publicKey)
-  t.alike(peerInfo.relayAddresses, relayAddresses, 'touching the peer preserves relay addresses')
-
-  swarm._upsertPeer(publicKey, null)
-  t.is(peerInfo.relayAddresses, null, 'explicit null clears relay addresses')
-})
-
 test('topics returns peer-discovery objects', async (t) => {
   const { bootstrap } = await createTestnet(3, t.teardown)
 

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -535,6 +535,26 @@ test(
   }
 )
 
+test('_upsertPeer preserves relay addresses on undefined and clears on null', async (t) => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+  const swarm = new Hyperswarm({ bootstrap })
+
+  t.teardown(async () => {
+    await swarm.destroy()
+  })
+
+  const publicKey = Buffer.alloc(32).fill(7)
+  const relayAddresses = [{ host: '127.0.0.1', port: 4242 }]
+
+  const peerInfo = swarm._upsertPeer(publicKey, relayAddresses)
+
+  swarm._upsertPeer(publicKey, undefined)
+  t.alike(peerInfo.relayAddresses, relayAddresses, 'explicit undefined preserves known hints')
+
+  swarm._upsertPeer(publicKey, null)
+  t.is(peerInfo.relayAddresses, null, 'null explicitly clears known hints')
+})
+
 test('topics returns peer-discovery objects', async (t) => {
   const { bootstrap } = await createTestnet(3, t.teardown)
 

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -476,6 +476,65 @@ test('rejoining with different client/server opts refreshes', async (t) => {
   await swarm2.destroy()
 })
 
+test(
+  'peer keeps discovered relay addresses after a later inbound connection',
+  { timeout: 30000 },
+  async (t) => {
+    const { bootstrap } = await createTestnet(3, t.teardown)
+
+    const swarm1 = new Hyperswarm({ bootstrap })
+    // Prevent swarm2 from immediately consuming the discovered peer as an outbound client
+    // connection. That lets us observe the discovered relayAddresses before the later inbound
+    // server-connection path for the same peer runs.
+    const swarm2 = new Hyperswarm({ bootstrap, maxClientConnections: 0 })
+
+    t.teardown(async () => {
+      await swarm1.destroy()
+      await swarm2.destroy()
+    })
+
+    const discoveryTopic = Buffer.alloc(32).fill('relay addresses discovery')
+    const inboundTopic = Buffer.alloc(32).fill('relay addresses inbound')
+
+    await swarm1.join(discoveryTopic, { client: false, server: true }).flushed()
+    swarm2.join(discoveryTopic, { client: true, server: false })
+
+    // First hit the normal public discovery path and wait until swarm2 has cached the relay
+    // addresses announced for swarm1.
+    const discoveredPeer = await waitForPeerWithRelayAddresses(swarm2, swarm1.keyPair.publicKey)
+    const relayAddresses = discoveredPeer.relayAddresses.map(({ host, port }) => ({ host, port }))
+
+    t.ok(relayAddresses.length > 0, 'discovery stored relay addresses through the public path')
+
+    const inboundOnSwarm2 = nextConnectionFromPeer(swarm2, swarm1.keyPair.publicKey)
+    const inboundOnSwarm1 = nextConnectionFromPeer(swarm1, swarm2.keyPair.publicKey)
+
+    // Then use a second topic to make swarm1 dial swarm2, so swarm2 reaches the real
+    // _handleServerConnection(...) path that used to overwrite relayAddresses with null.
+    await swarm2.join(inboundTopic, { client: false, server: true }).flushed()
+    swarm1.join(inboundTopic, { client: true, server: false })
+
+    const [serverConn] = await inboundOnSwarm2
+    const [clientConn] = await inboundOnSwarm1
+
+    await flushConnections(swarm1)
+    await flushConnections(swarm2)
+
+    const updatedPeer = swarm2.peers.get(b4a.toString(swarm1.keyPair.publicKey, 'hex'))
+
+    t.alike(
+      updatedPeer.relayAddresses,
+      relayAddresses,
+      'the later inbound server connection should not erase discovered relay addresses'
+    )
+
+    serverConn.on('error', noop)
+    clientConn.on('error', noop)
+    serverConn.destroy()
+    clientConn.destroy()
+  }
+)
+
 test('topics returns peer-discovery objects', async (t) => {
   const { bootstrap } = await createTestnet(3, t.teardown)
 
@@ -870,3 +929,31 @@ test('ban stat and event', async (t) => {
 })
 
 function noop() {}
+
+function nextConnectionFromPeer(swarm, publicKey) {
+  return new Promise((resolve) => {
+    swarm.on('connection', onconnection)
+
+    function onconnection(conn, info) {
+      if (!b4a.equals(info.publicKey, publicKey)) return
+      swarm.removeListener('connection', onconnection)
+      resolve([conn, info])
+    }
+  })
+}
+
+async function waitForPeerWithRelayAddresses(swarm, publicKey) {
+  const started = Date.now()
+  const key = b4a.toString(publicKey, 'hex')
+
+  while (Date.now() - started < 10000) {
+    const peerInfo = swarm.peers.get(key)
+    if (peerInfo && peerInfo.relayAddresses && peerInfo.relayAddresses.length > 0) {
+      return peerInfo
+    }
+
+    await timeout(20)
+  }
+
+  throw new Error('Timed out waiting for discovered relay addresses')
+}

--- a/test/swarm.js
+++ b/test/swarm.js
@@ -510,7 +510,7 @@ test(
     const inboundOnSwarm1 = nextConnectionFromPeer(swarm1, swarm2.keyPair.publicKey)
 
     // Then use a second topic to make swarm1 dial swarm2, so swarm2 reaches the real
-    // _handleServerConnection(...) path that used to overwrite relayAddresses with null.
+    // _handleServerConnection(...) path that touches an existing peer without new relay data.
     await swarm2.join(inboundTopic, { client: false, server: true }).flushed()
     swarm1.join(inboundTopic, { client: true, server: false })
 
@@ -534,6 +534,28 @@ test(
     clientConn.destroy()
   }
 )
+
+test('_upsertPeer preserves relay addresses on touch and clears on explicit null', async (t) => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+  const swarm = new Hyperswarm({ bootstrap })
+
+  t.teardown(async () => {
+    await swarm.destroy()
+  })
+
+  const publicKey = Buffer.alloc(32).fill('relay address contract')
+  const relayAddresses = [{ host: '1.2.3.4', port: 1234 }]
+
+  const peerInfo = swarm._upsertPeer(publicKey, relayAddresses)
+
+  t.alike(peerInfo.relayAddresses, relayAddresses, 'explicit relay addresses are stored')
+
+  swarm._upsertPeer(publicKey)
+  t.alike(peerInfo.relayAddresses, relayAddresses, 'touching the peer preserves relay addresses')
+
+  swarm._upsertPeer(publicKey, null)
+  t.is(peerInfo.relayAddresses, null, 'explicit null clears relay addresses')
+})
 
 test('topics returns peer-discovery objects', async (t) => {
   const { bootstrap } = await createTestnet(3, t.teardown)


### PR DESCRIPTION
Fixes a scenario when relay hints gets updated when defensive behaviour is prefered. 

Test was co-written with AI