### PR TITLE
Pass peerInfo to the relayThrough callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,9 +104,9 @@ module.exports = class Hyperswarm extends EventEmitter {
     this.on('update', this._handleUpdate)
   }
 
-  _maybeRelayConnection(force) {
+  _maybeRelayConnection(force, peerInfo) {
     if (!this.relayThrough) return null
-    return this.relayThrough(force, this)
+    return this.relayThrough(force, this, peerInfo)
   }
 
   _enqueue(peerInfo) {
@@ -207,7 +207,7 @@ module.exports = class Hyperswarm extends EventEmitter {
       return
     }
 
-    const relayThrough = this._maybeRelayConnection(peerInfo.forceRelaying)
+    const relayThrough = this._maybeRelayConnection(peerInfo.forceRelaying, peerInfo)
     const conn = this.dht.connect(peerInfo.publicKey, {
       relayAddresses: peerInfo.relayAddresses,
       keyPair: this.keyPair,

--- a/test/relay.js
+++ b/test/relay.js
@@ -93,3 +93,38 @@ function createForceRelayingHarness(bootstrap, code) {
     relayKey
   }
 }
+
+test('relayThrough is given the peerInfo of the peer being dialled', async (t) => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+  t.plan(2)
+
+  const relayKey = DHT.keyPair(Buffer.alloc(32, 'relay')).publicKey
+  const peerKey = DHT.keyPair(Buffer.alloc(32, 'peer')).publicKey
+
+  let seen
+  const swarm = new Hyperswarm({
+    bootstrap,
+    relayThrough (force, swarm, peerInfo) {
+      seen = peerInfo
+      return relayKey
+    }
+  })
+
+  swarm.dht.connect = function (publicKey) {
+    const conn = new EventEmitter()
+    conn.remotePublicKey = publicKey
+    setTimeout(() => {
+      conn.emit('error', new Error('nope'))
+      conn.emit('close')
+    }, 0)
+    return conn
+  }
+
+  swarm._connect(swarm._upsertPeer(peerKey), false)
+  await once(swarm, 'update')
+
+  t.ok(seen, 'the callback was given a peerInfo')
+  t.alike(seen && seen.publicKey, peerKey, 'it is the peer being dialled')
+
+  await swarm.destroy()
+})


### PR DESCRIPTION
`relayThrough` is called with `(force, swarm)`, so a callback can decide *whether* to relay but not *who* it is about. The peer being dialled is right there in `_connect` — this forwards it.

```js
_maybeRelayConnection(force, peerInfo) {
  if (!this.relayThrough) return null
  return this.relayThrough(force, this, peerInfo)
}
```

### Why

We relay through infrastructure we pay for, and we ask the user's permission per peer before we do. Without `peerInfo` the callback cannot tell which peer the dial is for, so the decision can only be global — all-or-nothing for every peer in the swarm. With it, the policy can be per-peer, which is what a consent prompt or a per-destination budget actually needs.

More generally: any relay policy that is not uniform across peers needs to know the peer. `force` already varies per peer (`peerInfo.forceRelaying`), so the callback is being asked a per-peer question with the per-peer context removed.

### Compatibility

Additive. Existing callbacks take `(force, swarm)` and are unaffected by a third argument.

### Test

`test/relay.js` gains a case asserting the callback receives a `peerInfo` whose `publicKey` is the peer being dialled, using the same stubbed-`dht.connect` harness as the existing force-relay test.

`npm run test:node` passes: 45/45 tests, 187/187 asserts. (`test:bare` was not run — no `bare` runtime on the machine I built this on.)