### PR TITLE
fix: CI duplicate bare install

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -26,5 +26,4 @@ jobs:
     steps:
       - uses: holepunchto/actions/bare-base@v1
       - run: npm test
-      - run: npm i -g bare
       - run: npm run test:bare


### PR DESCRIPTION
CI has a conflict in the step `npm i -g bare`, by the latest `bare-base@v1` doesn't seem to be needed anymore.

```
npm error File exists: /opt/hostedtoolcache/node/24.19.0/x64/bin/bare
```

logs https://github.com/holepunchto/hyperswarm/actions/runs/32834100059/job/97759018852?pr=224
