### PR TITLE
fix(bulk-timer): clear interval when idle and no items remain

### DIFF
--- a/lib/bulk-timer.js
+++ b/lib/bulk-timer.js
@@ -16,10 +16,13 @@ module.exports = class BulkTimer {
   }
 
   _ontick() {
-    if (!this._next.length && !this._pending.length) return
     if (this._next.length) this._fn(this._next)
     this._next = this._pending
     this._pending = []
+    if (!this._next.length) {
+      clearInterval(this._interval)
+      this._interval = null
+    }
   }
 
   add(info) {

--- a/test/bulk-timer.js
+++ b/test/bulk-timer.js
@@ -67,6 +67,33 @@ test('bulk timer - nothing pending', async (t) => {
   timer.destroy()
 })
 
+test('bulk timer - clears interval when idle and restarts on add', async (t) => {
+  let calls = 0
+  const batches = []
+  const timer = new BulkTimer(TEST_INTERVAL, (batch) => {
+    calls++
+    batches.push([...batch])
+  })
+
+  timer.add(1)
+  t.ok(timer._interval !== null, 'interval started')
+
+  await waitForCalls(1)
+  t.is(calls, 1)
+  t.alike(batches[0], [1])
+  t.is(timer._interval, null, 'interval cleared when idle')
+
+  timer.add(2)
+  t.ok(timer._interval !== null, 'interval restarted')
+
+  await waitForCalls(1)
+  t.is(calls, 2)
+  t.alike(batches[1], [2])
+  t.is(timer._interval, null, 'interval cleared again')
+
+  timer.destroy()
+})
+
 function waitForCalls(n) {
   return new Promise((resolve) => setTimeout(resolve, n * (TEST_INTERVAL * 1.5)))
 }


### PR DESCRIPTION
When \BulkTimer\ is populated via \dd(info)\, it creates an internal interval timer via \setInterval\ at \Math.floor(this._time * 0.66)\. Once all pending items in \_next\ and \_pending\ have been processed and drained, \_ontick()\ returned early without clearing the interval.

This leaves background \setInterval\ handles active indefinitely on the event loop during idle periods and leads to non-deterministic delay phases on subsequent \dd()\ calls.

This change clears and nullifies \	his._interval\ when both queues are empty, and adds a regression test in \	est/bulk-timer.js\ verifying interval cleanup on idle and restart on subsequent additions.