### PR TITLE
Extend `suspend.js` tests

### DIFF
--- a/test/suspend.js
+++ b/test/suspend.js
@@ -1,8 +1,8 @@
 const test = require('brittle')
+const DHT = require('hyperdht')
 const createTestnet = require('hyperdht/testnet')
 
 const Hyperswarm = require('..')
-const DHT = require('hyperdht')
 
 test('suspend + resume', async (t) => {
   t.plan(4)

--- a/test/suspend.js
+++ b/test/suspend.js
@@ -2,6 +2,7 @@ const test = require('brittle')
 const createTestnet = require('hyperdht/testnet')
 
 const Hyperswarm = require('..')
+const DHT = require('hyperdht')
 
 test('suspend + resume', async (t) => {
   t.plan(4)
@@ -41,4 +42,96 @@ test('suspend + resume', async (t) => {
     t.comment('resumed swarm2')
     swarm2.resume()
   }, 2000)
+})
+
+test('suspend + resume - a server re-announces on resume', async (t) => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+
+  const server = new Hyperswarm({ bootstrap })
+  t.teardown(() => server.destroy())
+
+  const probe = new DHT({ bootstrap })
+  t.teardown(() => probe.destroy())
+
+  const topic = Buffer.alloc(32).fill('re-announce')
+
+  await server.join(topic, { server: true, client: false }).flushed()
+  t.ok((await announced(topic)) > 0, 'announced')
+
+  await server.suspend()
+  t.is(await announced(topic), 0, 'unannounced on suspend()')
+
+  await server.resume()
+  await server.flush()
+  t.ok((await announced(topic)) > 0, 'reannounced on resume()')
+
+  async function announced(topic) {
+    let peers = 0
+    for await (const result of probe.lookup(topic)) peers += result.peers.length
+    return peers
+  }
+})
+
+test('suspend + resume - 2 peers both server and client', async (t) => {
+  const { bootstrap } = await createTestnet(3, t.teardown)
+
+  const a = new Hyperswarm({ bootstrap })
+  const b = new Hyperswarm({ bootstrap })
+
+  t.teardown(async () => {
+    await a.destroy()
+    await b.destroy()
+  })
+
+  const topic = Buffer.alloc(32).fill('symmetric roles')
+
+  const connected = Promise.all([
+    nextConnection(a),
+    nextConnection(b)
+  ])
+
+  await a.join(topic, { server: true, client: true }).flushed()
+  await b.join(topic, { server: true, client: true }).flushed()
+
+  t.comment('flushed')
+
+  await t.execution(connected, 'connected')
+  t.is(a.connections.size, 1, 'A connection')
+  t.is(b.connections.size, 1, 'B connection')
+
+  await Promise.all([a.suspend(), b.suspend()])
+  t.comment('suspended')
+
+  t.is(a.connections.size, 0, 'A no connection')
+  t.is(b.connections.size, 0, 'B no connection')
+
+  const reconnected = Promise.all([nextConnection(a), nextConnection(b)])
+
+  await a.resume()
+
+  // discovery.refresh() is not awaitable by resume()
+  await new Promise(function(resolve, reject) {
+    setTimeout(function() {
+      b.resume().then(resolve).catch(reject)
+    }, 1)
+  })
+
+  t.comment('resumed')
+
+  await reconnected
+  t.comment('reconnected after resume')
+
+  t.is(a.connections.size, 1, 'A connection')
+  t.is(b.connections.size, 1, 'B connection')
+
+  function nextConnection(swarm) {
+    return new Promise(function (resolve) {
+      swarm.once('connection', function(connection) {
+        connection.once('error', function(err) {
+          if (err.code !== 'ECONNRESET') throw err
+        })
+        resolve()
+      })
+    })
+  }
 })

--- a/test/suspend.js
+++ b/test/suspend.js
@@ -110,7 +110,7 @@ test('suspend + resume - 2 peers both server and client', async (t) => {
   await new Promise(function (resolve, reject) {
     setTimeout(function () {
       b.resume().then(resolve).catch(reject)
-    }, 1)
+    }, 100)
   })
 
   t.comment('resumed')

--- a/test/suspend.js
+++ b/test/suspend.js
@@ -107,11 +107,8 @@ test('suspend + resume - 2 peers both server and client', async (t) => {
   await a.resume()
 
   // discovery.refresh() is not awaitable by resume()
-  await new Promise(function (resolve, reject) {
-    setTimeout(function () {
-      b.resume().then(resolve).catch(reject)
-    }, 100)
-  })
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  await b.resume()
 
   t.comment('resumed')
 
@@ -122,11 +119,12 @@ test('suspend + resume - 2 peers both server and client', async (t) => {
   t.is(b.connections.size, 1, 'B connection')
 
   function nextConnection(swarm) {
-    return new Promise(function (resolve) {
-      swarm.once('connection', function (connection) {
-        connection.once('error', function (err) {
+    return new Promise((resolve) => {
+      swarm.once('connection', (connection) => {
+        connection.once('error', (err) => {
           if (err.code !== 'ECONNRESET') throw err
         })
+
         resolve()
       })
     })

--- a/test/suspend.js
+++ b/test/suspend.js
@@ -85,10 +85,7 @@ test('suspend + resume - 2 peers both server and client', async (t) => {
 
   const topic = Buffer.alloc(32).fill('symmetric roles')
 
-  const connected = Promise.all([
-    nextConnection(a),
-    nextConnection(b)
-  ])
+  const connected = Promise.all([nextConnection(a), nextConnection(b)])
 
   await a.join(topic, { server: true, client: true }).flushed()
   await b.join(topic, { server: true, client: true }).flushed()
@@ -110,8 +107,8 @@ test('suspend + resume - 2 peers both server and client', async (t) => {
   await a.resume()
 
   // discovery.refresh() is not awaitable by resume()
-  await new Promise(function(resolve, reject) {
-    setTimeout(function() {
+  await new Promise(function (resolve, reject) {
+    setTimeout(function () {
       b.resume().then(resolve).catch(reject)
     }, 1)
   })
@@ -126,8 +123,8 @@ test('suspend + resume - 2 peers both server and client', async (t) => {
 
   function nextConnection(swarm) {
     return new Promise(function (resolve) {
-      swarm.once('connection', function(connection) {
-        connection.once('error', function(err) {
+      swarm.once('connection', function (connection) {
+        connection.once('error', function (err) {
           if (err.code !== 'ECONNRESET') throw err
         })
         resolve()


### PR DESCRIPTION
**Test 1**
Asserts that an `server: true` peer re-announces after suspension.

**Test 2**
Asserts that re-connection occurs given that the two peers resumption is staggered.
This case can only occur in a test or sim environment.